### PR TITLE
mrc-1617 Add defaults for net_use and irs_use in intervention options

### DIFF
--- a/inst/json/intervention_options.json
+++ b/inst/json/intervention_options.json
@@ -124,7 +124,7 @@
                                 {"id": "0.9", "label": "90% usage"},
                                 {"id": "1", "label": "100% usage"}
                             ],
-                            "value": "0.6"
+                            "value": "0"
                         }
                     ]
                 },
@@ -144,7 +144,7 @@
                                 {"id": "0.9", "label": "90% coverage"},
                                 {"id": "1", "label": "100% coverage"}
                             ],
-                            "value": "0.9"
+                            "value": "0"
                         }
                     ]
                 }

--- a/inst/json/intervention_options.json
+++ b/inst/json/intervention_options.json
@@ -123,7 +123,8 @@
                                 {"id": "0.8", "label": "80% usage"},
                                 {"id": "0.9", "label": "90% usage"},
                                 {"id": "1", "label": "100% usage"}
-                            ]
+                            ],
+                            "value": "0.6"
                         }
                     ]
                 },
@@ -142,7 +143,8 @@
                                 {"id": "0.8", "label": "80% coverage"},
                                 {"id": "0.9", "label": "90% coverage"},
                                 {"id": "1", "label": "100% coverage"}
-                            ]
+                            ],
+                            "value": "0.9"
                         }
                     ]
                 }


### PR DESCRIPTION
These correspond with the defaults for Intervention Coverage Potential in the existing shiny app: https://shiny.dide.imperial.ac.uk:9000/staging/malaria_vector_control_decisions_tool/

You should see these default set int he web app if you run mint locally, having set the version in src/config/mintr_version to mrc-1617.