### PR TITLE
mrc-1861: Update intervention names to use short codes

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -98,15 +98,15 @@ mint_db_check_prevalence <- function(index, prevalence) {
 
 
 mint_intervention <- function(net_use, irs_use, net_type) {
-  intervention <- c(                # net_use  irs_use  net_type
-    "No intervention",              # == 0     == 0     == std
-    "Pyrethroid LLIN only",         #  > 0     == 0     == std
-    "IRS only",                     # == 0      > 0     == std
-    "Pyrethroid LLIN with IRS",     #  > 0      > 0     == std
-    "No intervention",              # == 0     == 0     == pto
-    "Pyrethroid-PBO LLIN only",     #  > 0     == 0     == pto
-    "IRS only",                     # == 0      > 0     == pto
-    "Pyrethroid-PBO LLIN with IRS") #  > 0      > 0     == pto
+  intervention <- c(# net_use  irs_use  net_type
+    "none",         # == 0     == 0     == std
+    "llin",         #  > 0     == 0     == std
+    "irs",          # == 0      > 0     == std
+    "irs-llin",     #  > 0      > 0     == std
+    "none",         # == 0     == 0     == pto
+    "llin-pbo",     #  > 0     == 0     == pto
+    "irs",          # == 0      > 0     == pto
+    "irs-llin-pbo") #  > 0      > 0     == pto
 
   ## Use bit packing to get the above relationship:
   i <- (net_use > 0) + (irs_use > 0) * 2 + (net_type == "pto") * 4 + 1

--- a/import/README.md
+++ b/import/README.md
@@ -1,0 +1,13 @@
+## Importing data
+
+This will evolve as the upstream data changes and as our needs change. These scripts will create rds files that can be used to initialise the app. We'll store these either on mrcdata.dide.ic.ac.uk or as github release artefacts and pull them in fairly automatically during deployment.  They will expand into the actual mint database, which is much larger than the rds but faster to read.
+
+The process (best carried out on Imperial's network).
+
+1. Acquire new data from the science team; this will come in an "index" and "values" file and place them in this directory.
+2. Update the names in `scripts/import.R`; likely the dates will have changed
+3. Run the script `scripts/import.R` which processes the data and ensures that it's possible to build the database
+4. Copy the resulting files (`import/index.rds` and `import/prevalence.rds`) to a network directory (e.g., `~/net/home/mint`)
+5. Connect to mrcdata via RDP and move these files into the path `C:\xampp\htdocs\mrcdata\mint` on the server
+
+The files are now available as https://mrcdata.dide.ic.ac.uk/mint/index.rds and https://mrcdata.dide.ic.ac.uk/mint/prevalence.rds

--- a/scripts/import.R
+++ b/scripts/import.R
@@ -75,6 +75,17 @@ tr <- c(netUse = "switch_nets", irsUse = "switch_irs", netType = "NET_TYPE")
 prevalence <- rename(prevalence, unname(tr), names(tr))
 prevalence$netType <- relevel(prevalence$netType, c(std = 1, pto = 2))
 
+prevalence_config <-
+  jsonlite::read_json("inst/json/graph_prevalence_config.json")
+prevalence_map <- character()
+for (x in prevalence_config$series) {
+  if (!is.null(x$id)) {
+    prevalence_map[[x$id]] <- x$name
+  }
+}
+
+prevalence$intervention <- relevel(prevalence$intervention, prevalence_map)
+
 saveRDS(index, file.path(path_import, "index.rds"))
 saveRDS(prevalence, file.path(path_import, "prevalence.rds"))
 

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -101,7 +101,7 @@ test_that("prevelance must conform", {
 
   expect_silent(mint_db_check_prevalence(index, prevalence))
 
-  i <- which(prevalence$intervention == "IRS only")[10]
+  i <- which(prevalence$intervention == "irs")[10]
 
   prevalence$intervention[i] <- "other"
   expect_error(


### PR DESCRIPTION
This PR remaps the intervention names to short codes ("none", "irs-llin-pbo", etc) rather than human readable codes ("Pyrethroid-PBO LLIN with IRS", well not *that* human readable).

We discussed that we should refactor how the import works to make it more enjoyable to do, which is now https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1862 and not done here