### PR TITLE
update table definitions schema and config

### DIFF
--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -1,6 +1,18 @@
-{
-    "intervention": "Interventions",
-    "netUse": "Net use (%)",
-    "irsUse": "IRS cover (%)",
-    "casesAvertedPer1000": "Mean cases averted per 1,000 people per year (across 3 yrs since intervention)"
-}
+[
+  {
+    "valueCol": "intervention",
+    "displayName": "Interventions"
+  },
+  {
+    "valueCol": "netUse",
+    "displayName": "Net use (%)"
+  },
+  {
+    "valueCol": "irsUse",
+    "displayName": "IRS cover (%)"
+  },
+  {
+    "valueCol": "casesAvertedPer1000",
+    "displayName": "Mean cases averted per 1,000 people per year (across 3 yrs since intervention)"
+  }
+]

--- a/inst/json/table_impact_config.json
+++ b/inst/json/table_impact_config.json
@@ -1,13 +1,46 @@
-{
-    "intervention": "Interventions",
-    "netUse": "Net use (%)",
-    "irsUse": "IRS cover (%)",
-    "prevYear1": "Prevalence Under 10 yrs: Yr 1 post intervention",
-    "prevYear2": "Prevalence Under 10 yrs: Yr 2 post intervention",
-    "prevYear3": "Prevalence Under 10 yrs: Yr 3 post intervention",
-    "reductionInPrevalence": "Relative reduction in prevalence in under 10 years (%)",
-    "casesAverted": "Mean cases averted across 3 yrs since intervention",
-    "casesAvertedPer1000": "Mean cases averted per 1000 people across 3 yrs since intervention",
-    "reductionInCases": "Relative reduction in clinical cases across 3 yrs since intervention (%)",
-    "meanCases": "Mean cases per person per year across 3 yrs"
-}
+[
+  {
+    "valueCol": "intervention",
+    "displayName": "Interventions"
+  },
+  {
+    "valueCol": "netUse",
+    "displayName": "Net use (%)"
+  },
+  {
+    "valueCol": "irsUse",
+    "displayName": "IRS cover (%)"
+  },
+  {
+    "valueCol": "prevYear1",
+    "displayName": "Prevalence Under 10 yrs: Yr 1 post intervention"
+  },
+  {
+    "valueCol": "prevYear2",
+    "displayName": "Prevalence Under 10 yrs: Yr 2 post intervention"
+  },
+  {
+    "valueCol": "prevYear3",
+    "displayName": "Prevalence Under 10 yrs: Yr 3 post intervention"
+  },
+  {
+    "valueCol": "reductionInPrevalence",
+    "displayName": "Relative reduction in prevalence in under 10 years (%)"
+  },
+  {
+    "valueCol": "casesAverted",
+    "displayName": "Mean cases averted across 3 yrs since intervention"
+  },
+  {
+    "valueCol": "casesAvertedPer1000",
+    "displayName": "Mean cases averted per 1000 people across 3 yrs since intervention"
+  },
+  {
+    "valueCol": "reductionInCases",
+    "displayName": "Relative reduction in clinical cases across 3 yrs since intervention (%)"
+  },
+  {
+    "valueCol": "meanCases",
+    "displayName": "Mean cases per person per year across 3 yrs"
+  }
+]

--- a/inst/schema/TableDefinition.schema.json
+++ b/inst/schema/TableDefinition.schema.json
@@ -7,10 +7,7 @@
       "properties": {
         "valueCol": {"type": "string"},
         "displayName": {"type": "string"},
-        "valueTransform": {
-          "type": "array",
-          "items": {"type": "string"}
-        },
+        "valueTransform": {"type": "object"},
         "format": {"type": "string"}
       },
       "additionalProperties": false,

--- a/inst/schema/TableDefinition.schema.json
+++ b/inst/schema/TableDefinition.schema.json
@@ -1,5 +1,26 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "additionalProperties": true
+  "type": "array",
+  "definitions": {
+    "columnDefinition": {
+      "type": "object",
+      "properties": {
+        "valueCol": {"type": "string"},
+        "displayName": {"type": "string"},
+        "valueTransform": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "format": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "required": [
+        "valueCol",
+        "displayName"
+      ]
+    }
+  },
+  "items": {
+    "$ref": "#/definitions/columnDefinition"
+  }
 }


### PR DESCRIPTION
Just updates the existing table config to match the new schema as worked out here: https://github.com/reside-ic/vue-prototypes/pull/8. Doesn't yet add the cost calculations or display names, there's a separate ticket for that.