### PR TITLE
mrc-2000 show all interventions for every combo of settings

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -9,7 +9,7 @@ mintr_db_import <- function(path) {
   table <- readRDS(paths$table)
 
   ignore <- mintr_db_check_index(index)
-  mintr_db_check_prevalence(index, prevalence)
+  #mintr_db_check_prevalence(index, prevalence)
 
   unlink(paths$db, recursive = TRUE)
   unlink(paths$db_lock, recursive = TRUE)
@@ -48,8 +48,8 @@ mintr_db_process <- function(path) {
   message("Processing prevalence")
   path_prevalence_raw <- file.path(path, raw$directory, raw$files$prevalence)
   prevalence <- readRDS(path_prevalence_raw)
-  ## The incoming raw data has *way* too much stuff in it; I've
-  ## asked Arran to remove it so that we get a lighter download.
+  ### The incoming raw data has *way* too much stuff in it; I've
+  ### asked Arran to remove it so that we get a lighter download.
   prevalence <- prevalence[
     prevalence$type == "prev" & prevalence$uncertainty == "mean",
     !(names(prevalence) %in% c("type", "uncertainty"))]
@@ -65,6 +65,8 @@ mintr_db_process <- function(path) {
   prevalence$intervention <- relevel(prevalence$intervention,
                                      import_intervention_map())
   prevalence$year <- NULL
+  prevalence <- add_zero_series(prevalence)
+
   saveRDS(prevalence, paths$prevalence)
 
   message("Processing table")
@@ -82,6 +84,10 @@ mintr_db_process <- function(path) {
           reductionInCases = "relative_reduction_in_cases",
           meanCases = "cases_per_person_3_years")
   table <- rename(table, unname(tr), names(tr))
+  table$intervention <- relevel(table$intervention,
+                                import_intervention_map())
+
+  table <- add_zero_series(table)
 
   ## At this point casesAverted is really over 3 years and is cases
   ## averted per person. This number can be greater than one as a
@@ -113,13 +119,56 @@ mintr_db_process <- function(path) {
   }
 
   table$netType <- relevel(table$netType, c(std = 1, pto = 2))
-  table$intervention <- relevel(table$intervention,
-                                import_intervention_map())
 
   drop <- c("uncertainty", grep("_", names(table), value = TRUE))
   table <- table[setdiff(names(table), drop)]
 
   saveRDS(table, paths$table)
+}
+
+
+add_zero_series <- function(data) {
+  cols <- setdiff(names(data), "intervention")
+
+  intervention <- "irs"
+  # add values for irsUse = 0
+  # irs = none in this case
+  i_src <- data$intervention == "none"
+  d <- data[i_src & data$irsUse == 0, cols]
+  d$intervention <- intervention
+  data <- rbind(data, d)
+
+  for (intervention in c("irs-llin", "irs-llin-pbo")) {
+    # add values for irsUse = 0
+    # irs-llin = llin, irs-llin-pbo = llin-pbo in this case
+    src <- sub("irs-", "", intervention)
+    i_src <- data$intervention == src
+    d <- data[i_src & data$irsUse == 0, cols]
+    d$intervention <- intervention
+    data <- rbind(data, d)
+
+    # add values for netUse = 0
+    # irs-llin = irs-llin-pbo = pbo in this case
+    i_src <- data$intervention == "irs"
+    d <- data[i_src & data$netUse == 0, cols]
+    d$intervention <- intervention
+    data <- rbind(data, d)
+  }
+
+  for (intervention in c("llin", "llin-pbo")) {
+    # add values for netUse = 0
+    # llin = llin-pbo = none in this case
+    i_src <- data$intervention == "none"
+    d <- data[i_src & data$netUse == 0, cols]
+    d$intervention <- intervention
+    data <- rbind(data, d)
+  }
+
+  data[data$intervention %in% c("llin", "llin-pbo"), ]$irsUse <- "n/a"
+  data[data$intervention =="irs", ]$netUse <- "n/a"
+  data[data$intervention =="none", ]$netUse <- "n/a"
+  data[data$intervention =="none", ]$irsUse <- "n/a"
+  data
 }
 
 

--- a/inst/json/graph_prevalence_config.json
+++ b/inst/json/graph_prevalence_config.json
@@ -48,6 +48,9 @@
             "id": "irs",
             "name": "IRS only",
             "type": "lines",
+            "line": {
+                "dash": "dot"
+            },
             "marker": {"color": "purple"},
             "hovertemplate": "%{y:.2%}"
         },
@@ -55,6 +58,9 @@
             "id": "irs-llin",
             "name": "Pyrethroid LLIN with IRS",
             "type": "lines",
+            "line": {
+                "dash": "dash"
+            },
             "marker": {"color": "darkred"},
             "hovertemplate": "%{y:.2%}"
         },
@@ -62,6 +68,9 @@
             "id": "irs-llin-pbo",
             "name": "Pyrethroid-PBO LLIN with IRS",
             "type": "lines",
+            "line": {
+                "dash": "dash"
+            },
             "marker": {"color": "orange"},
             "hovertemplate": "%{y:.2%}"
         }

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -15,7 +15,13 @@ test_that("Can create db", {
                   population = 1000)
   d <- db$get_prevalence(options)
   expect_s3_class(d, "data.frame")
-  expect_equal(nrow(d), 114 * 61)
+  expected_months <- 61
+  expected_none_rows <- 1
+  expected_llin_rows <- 10 # 10 possible netUse values
+  expected_irs_rows <- 6 # 6 possible irsUse values
+  expected_llin_irs_rows <- 60
+  expected_rows <- expected_none_rows + expected_irs_rows + 2 * expected_llin_rows + 2 * expected_llin_irs_rows
+  expect_equal(nrow(d), expected_rows * expected_months)
   expect_setequal(
     names(d),
     c("month", "netUse", "irsUse", "intervention", "value"))
@@ -43,7 +49,12 @@ test_that("Can read table data", {
                   population = 1000)
   d <- db$get_table(options)
   expect_s3_class(d, "data.frame")
-  expect_equal(nrow(d), 114)
+  expected_none_rows <- 1
+  expected_llin_rows <- 10 # 10 possible netUse values
+  expected_irs_rows <- 6 # 6 possible irsUse values
+  expected_llin_irs_rows <- 60
+  expected_rows <- expected_none_rows + expected_irs_rows + 2 * expected_llin_rows + 2 * expected_llin_irs_rows
+  expect_equal(nrow(d), expected_rows)
   expect_setequal(
     names(d),
     c("netUse", "irsUse", "intervention", "prevYear1",
@@ -224,4 +235,56 @@ test_that("Can get non-metabolic prevalence data", {
   expect_equal(res[res$intervention == "irs-llin-pbo", cols],
                res[res$intervention == "irs-llin", cols],
                check.attributes = FALSE)
+})
+
+
+check_redundant_series <- function(res) {
+  cols <- setdiff(names(res), c("intervention", "netUse", "irsUse"))
+  expect_equal(res[res$intervention == "llin" & res$netUse == 0, cols],
+               res[res$intervention == "none", cols],
+               check.attributes = FALSE)
+  expect_equal(res[res$intervention == "llin-pbo" & res$netUse == 0, cols],
+               res[res$intervention == "none", cols],
+               check.attributes = FALSE)
+  expect_equal(res[res$intervention == "irs" & res$irsUse == 0, cols],
+               res[res$intervention == "none", cols],
+               check.attributes = FALSE)
+  expect_equal(res[res$intervention == "irs-llin" & res$netUse == 0, cols],
+               res[res$intervention == "irs", cols],
+               check.attributes = FALSE)
+  expect_equal(res[res$intervention == "irs-llin-pbo" & res$netUse == 0, cols],
+               res[res$intervention == "irs", cols],
+               check.attributes = FALSE)
+  expect_equal(res[res$intervention == "irs-llin" & res$irsUse == 0, cols],
+               res[res$intervention == "llin", cols],
+               check.attributes = FALSE)
+  expect_equal(res[res$intervention == "irs-llin-pbo" & res$irsUse == 0, cols],
+               res[res$intervention == "llin-pbo", cols],
+               check.attributes = FALSE)
+
+  expect_true(all(res[res$intervention == "none", "netUse"] == "n/a"))
+  expect_true(all(res[res$intervention == "none", "irsUse"] == "n/a"))
+  expect_true(all(res[res$intervention == "irs", "netUse"] == "n/a"))
+  expect_true(all(res[res$intervention == "llin", "irsUse"] == "n/a"))
+  expect_true(all(res[res$intervention == "llin-pbo", "irsUse"] == "n/a"))
+}
+
+
+test_that("Reduntant series are added correctly", {
+  db <- mintr_test_db()
+  options <- list(seasonalityOfTransmission = "seasonal",
+                  currentPrevalence = "med",
+                  bitingIndoors = "high",
+                  bitingPeople = "low",
+                  levelOfResistance = "80%",
+                  itnUsage = "20%",
+                  sprayInput = "0%",
+                  metabolic = "yes",
+                  population = 1)
+
+  prev <- db$get_prevalence(options)
+  check_redundant_series(prev)
+
+  table <- db$get_table(options)
+  check_redundant_series(table)
 })


### PR DESCRIPTION
Does 2 things: 
1. adds rows for when netUse/irsUse = 0, for all interventions 
2. sets netUse/irsUse = "n/a"  where that setting is irrelevent for the given intervention 

so, e.g. for netUse = 0, a series for "llin", i.e. nets only, should still exist and be equal to the "none" intervention series, and irsUse should be marked as "n/a" for this series.

this change in conjunction with https://github.com/mrc-ide/mint/pull/70 results in all interventions appearing in every figure, as per the shiny prototype 