### PR TITLE
mrc-2089 Round cases averted to nearest 10, costs to nearest $0.10

### DIFF
--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -22,8 +22,11 @@
     "format": "0%"
   },
   {
-    "valueCol": "casesAvertedPer1000",
-    "displayName": "Mean cases averted per 1,000 people per year (across 3 yrs since intervention)"
+    "valueCol": "",
+    "displayName": "Mean cases averted per 1,000 people per year (across 3 yrs since intervention)",
+    "valueTransform": {
+      "undefined": "round({casesAvertedPer1000} / 10) * 10"
+    }
   },
   {
     "valueCol": "intervention",
@@ -58,11 +61,11 @@
     "displayName": "Costs per case averted",
     "valueTransform": {
       "none": "'reference'",
-      "llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",
-      "llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",
-      "irs": "(({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}",
-      "irs-llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}",
-      "irs-llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}"
+      "llin": "round(((({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}) * 10) / 10",
+      "llin-pbo": "round(((({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}) * 10) / 10",
+      "irs": "round(((({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}) * 10) / 10",
+      "irs-llin": "round(((({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}) * 10) / 10",
+      "irs-llin-pbo": "round(((({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}) * 10 ) / 10"
     },
     "format": "$0.00"
   }

--- a/inst/json/table_impact_config.json
+++ b/inst/json/table_impact_config.json
@@ -38,12 +38,18 @@
     "displayName": "Relative reduction in prevalence in under 10 years (%)"
   },
   {
-    "valueCol": "casesAverted",
-    "displayName": "Mean cases averted per population per year across 3 yrs since intervention"
+    "valueCol": "",
+    "displayName": "Mean cases averted per population per year across 3 yrs since intervention",
+    "valueTransform": {
+      "undefined": "round({casesAverted} / 10) * 10"
+    }
   },
   {
-    "valueCol": "casesAvertedPer1000",
-    "displayName": "Mean cases averted per 1000 people across 3 yrs since intervention"
+    "valueCol": "",
+    "displayName": "Mean cases averted per 1000 people across 3 yrs since intervention",
+    "valueTransform": {
+      "undefined": "round({casesAvertedPer1000} / 10) * 10"
+    }
   },
   {
     "valueCol": "reductionInCases",

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -274,14 +274,14 @@ test_that("cost table config formulas give correct results for costs per cases a
   none <- formulas[[1]]
   expect_equal(evaluate(none), "reference")
   ITN <- formulas[[2]]
-  expect_equal(evaluate(ITN), costs$costs_N1)
+  expect_equal(evaluate(ITN), costs$costs_N1, tolerance=0.05)
   PBO <- formulas[[3]]
-  expect_equal(evaluate(PBO), costs$costs_N2)
+  expect_equal(evaluate(PBO), costs$costs_N2, tolerance=0.05)
   IRS <- formulas[[4]]
-  expect_equal(evaluate(IRS), costs$costs_S1)
+  expect_equal(evaluate(IRS), costs$costs_S1, tolerance=0.05)
   ITN_IRS <- formulas[[5]]
-  expect_equal(evaluate(ITN_IRS), costs$costs_N1_S1)
+  expect_equal(evaluate(ITN_IRS), costs$costs_N1_S1, tolerance=0.05)
   PBO_IRS <- formulas[[6]]
-  expect_equal(evaluate(PBO_IRS), costs$costs_N2_S1)
+  expect_equal(evaluate(PBO_IRS), costs$costs_N2_S1, tolerance=0.05)
 
 })


### PR DESCRIPTION
I've struggled to find an elegant approach here - but this one is at least minimally invasive. Other suggestions very welcome! It turns out that presenting values to the nearest x isn't easily accomplished using our existing approach of using numeral.js formats or `toPrecision`. This is because it depends on the value itself (i.e. isn't directly related to number of significant figures or decimal places) and because rounding changes the value itself. I tried allowing negative precisions and allowing formulae in the `format` field but it got rather convoluted.