### PR TITLE
mrc-2091 Add Cost per case averted column to cost-effectiveness table

### DIFF
--- a/inst/json/cost_docs.md
+++ b/inst/json/cost_docs.md
@@ -22,4 +22,4 @@ clinical cases per 1,000 people averted by the intervention package relaive to t
  intervention package to cover a 3-year period of protection.
 *   Incremental increase in costs: The absolute increase in cost (USD) required for the intervention package relative 
 to the cost spent to achieve the 'do-nothing' scenario.
-*   Cost per case averted: The cost in USD per case averted relative to the 'do-nothing' scenario.
+*   Cost per case averted per 3-year campaign: The cost in USD per case averted relative to the 'do-nothing' scenario.

--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -55,7 +55,7 @@
   },
   {
     "valueCol": "intervention",
-    "displayName": "Costs per case averted",
+    "displayName": "Cost per case averted per 3-year campaign",
     "valueTransform": {
       "none": "'reference'",
       "llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",


### PR DESCRIPTION
Rename final column in the cost effectiveness table.

Looking at the values in the table and Ellie's original message this appears to be the requirement, rather than that of adding a new column.