### PR TITLE
mrc-2106 Add ability to transform table values prior to formatting

### DIFF
--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -22,11 +22,9 @@
     "format": "0%"
   },
   {
-    "valueCol": "",
+    "valueCol": "casesAvertedPer1000",
     "displayName": "Mean cases averted per 1,000 people per year (across 3 yrs since intervention)",
-    "valueTransform": {
-      "undefined": "round({casesAvertedPer1000} / 10) * 10"
-    }
+    "transform": "round({} / 10) * 10"
   },
   {
     "valueCol": "intervention",
@@ -61,12 +59,13 @@
     "displayName": "Costs per case averted",
     "valueTransform": {
       "none": "'reference'",
-      "llin": "round(((({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}) * 10) / 10",
-      "llin-pbo": "round(((({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}) * 10) / 10",
-      "irs": "round(((({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}) * 10) / 10",
-      "irs-llin": "round(((({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}) * 10) / 10",
-      "irs-llin-pbo": "round(((({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}) * 10 ) / 10"
+      "llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",
+      "llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",
+      "irs": "(({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}",
+      "irs-llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}",
+      "irs-llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}"
     },
+    "transform": "round({} * 10) / 10",
     "format": "$0.00"
   }
 ]

--- a/inst/json/table_impact_config.json
+++ b/inst/json/table_impact_config.json
@@ -41,18 +41,14 @@
     "displayName": "Relative reduction in prevalence in under 10 years (%)"
   },
   {
-    "valueCol": "",
+    "valueCol": "casesAverted",
     "displayName": "Mean cases averted per population per year across 3 yrs since intervention",
-    "valueTransform": {
-      "undefined": "round({casesAverted} / 10) * 10"
-    }
+    "transform": "round({} / 10) * 10"
   },
   {
-    "valueCol": "",
+    "valueCol": "casesAvertedPer1000",
     "displayName": "Mean cases averted per 1000 people across 3 yrs since intervention",
-    "valueTransform": {
-      "undefined": "round({casesAvertedPer1000} / 10) * 10"
-    }
+    "transform": "round({} / 10) * 10"
   },
   {
     "valueCol": "reductionInCases",

--- a/inst/schema/Graph.schema.json
+++ b/inst/schema/Graph.schema.json
@@ -46,8 +46,8 @@
             "type": "string"
           }
         },
-        "id": {"type:" :"string"},
-        "name": {"type":  "string"},
+        "id": {"type": "string"},
+        "name": {"type": "string"},
         "type": {"type": "string"}
       },
       "additionalProperties": true

--- a/inst/schema/TableDefinition.schema.json
+++ b/inst/schema/TableDefinition.schema.json
@@ -8,8 +8,9 @@
         "valueCol": {"type": "string"},
         "displayName": {"type": "string"},
         "valueTransform": {"type": "object"},
+        "transform": {"type": "string"},
         "format": {"type": "string"},
-        "precision": {"type":  "number"}
+        "precision": {"type": "number"}
       },
       "additionalProperties": false,
       "required": [

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -291,14 +291,14 @@ test_that("cost table config formulas give correct results for costs per cases a
   none <- formulas[[1]]
   expect_equal(evaluate(none), "reference")
   ITN <- formulas[[2]]
-  expect_equal(evaluate(ITN), costs$costs_N1, tolerance=0.05)
+  expect_equal(evaluate(ITN), costs$costs_N1)
   PBO <- formulas[[3]]
-  expect_equal(evaluate(PBO), costs$costs_N2, tolerance=0.05)
+  expect_equal(evaluate(PBO), costs$costs_N2)
   IRS <- formulas[[4]]
-  expect_equal(evaluate(IRS), costs$costs_S1, tolerance=0.05)
+  expect_equal(evaluate(IRS), costs$costs_S1)
   ITN_IRS <- formulas[[5]]
-  expect_equal(evaluate(ITN_IRS), costs$costs_N1_S1, tolerance=0.05)
+  expect_equal(evaluate(ITN_IRS), costs$costs_N1_S1)
   PBO_IRS <- formulas[[6]]
-  expect_equal(evaluate(PBO_IRS), costs$costs_N2_S1, tolerance=0.05)
+  expect_equal(evaluate(PBO_IRS), costs$costs_N2_S1)
 
 })


### PR DESCRIPTION
See mrc-ide/mint#79.

This also fixes a typo in `Graph.schema.json`, which was necessary to ensure that the newly generated types are compatible with the existing mint code.