### PR TITLE
Add uncertainty to table values

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -59,7 +59,9 @@ mintr_db <- R6::R6Class(
     get_table = function(options) {
       key <- self$get_index(options)
       ret <- unserialize(private$db$get(sprintf("table:%s", key)))
-      ret$casesAverted <- round(ret$casesAverted * options$population)
+      for (v in c("casesAverted", "casesAvertedErrorMinus", "casesAvertedErrorPlus")) {
+        ret[[v]] <- round(ret[[v]] * options$population)
+      }
       table <- mintr_db_transform_metabolic(ret, options$metabolic)
       mintr_db_set_not_applicable_values(table)
     }

--- a/R/import.R
+++ b/R/import.R
@@ -106,7 +106,14 @@ mintr_db_process <- function(path) {
   stopifnot(identical(table[v_index], t_low[v_index]),
             identical(table[v_index], t_high[v_index]))
 
-  v_uncertainty <- c("casesAvertedPer1000", "reductionInCases")
+  v_uncertainty <- c("casesAverted",
+                     "casesAvertedPer1000",
+                     "prevYear1",
+                     "prevYear2",
+                     "prevYear3",
+                     "reductionInPrevalence",
+                     "reductionInCases",
+                     "meanCases")
   for (v in v_uncertainty) {
     table[[paste0(v, "ErrorMinus")]] <- t_low[[v]]
     table[[paste0(v, "ErrorPlus")]] <- t_high[[v]]

--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -24,6 +24,14 @@
   {
     "valueCol": "casesAvertedPer1000",
     "displayName": "Mean cases averted per 1,000 people per year (across 3 yrs since intervention)",
+    "error": {
+      "minus": {
+        "valueCol": "casesAvertedPer1000ErrorMinus"
+      },
+      "plus": {
+        "valueCol": "casesAvertedPer1000ErrorPlus"
+      }
+    },
     "transform": "round({} / 10) * 10"
   },
   {
@@ -64,6 +72,28 @@
       "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
       "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
       "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"
+    },
+    "error": {
+      "minus": {
+        "valueTransform": {
+          "none": "'reference'",
+          "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}",
+          "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}",
+          "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}",
+          "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}",
+          "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}"
+        }
+      },
+      "plus": {
+        "valueTransform": {
+          "none": "'reference'",
+          "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}",
+          "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}",
+          "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}",
+          "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}",
+          "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"
+        }
+      }
     },
     "transform": "round({} * 10) / 10",
     "format": "$0.00"

--- a/inst/json/table_impact_config.json
+++ b/inst/json/table_impact_config.json
@@ -24,38 +24,102 @@
   {
     "valueCol": "prevYear1",
     "displayName": "Prevalence Under 10 yrs: Yr 1 post intervention",
+    "error": {
+      "minus": {
+        "valueCol": "prevYear1ErrorMinus"
+      },
+      "plus": {
+        "valueCol": "prevYear1ErrorPlus"
+      }
+    },
     "format": "0"
   },
   {
     "valueCol": "prevYear2",
     "displayName": "Prevalence Under 10 yrs: Yr 2 post intervention",
+    "error": {
+      "minus": {
+        "valueCol": "prevYear2ErrorMinus"
+      },
+      "plus": {
+        "valueCol": "prevYear2ErrorPlus"
+      }
+    },
     "format": "0"
   },
   {
     "valueCol": "prevYear3",
     "displayName": "Prevalence Under 10 yrs: Yr 3 post intervention",
+    "error": {
+      "minus": {
+        "valueCol": "prevYear3ErrorMinus"
+      },
+      "plus": {
+        "valueCol": "prevYear3ErrorPlus"
+      }
+    },
     "format": "0"
   },
   {
     "valueCol": "reductionInPrevalence",
-    "displayName": "Relative reduction in prevalence in under 10 years (%)"
+    "displayName": "Relative reduction in prevalence in under 10 years (%)",
+    "error": {
+      "minus": {
+        "valueCol": "reductionInPrevalenceErrorMinus"
+      },
+      "plus": {
+        "valueCol": "reductionInPrevalenceErrorPlus"
+      }
+    }
   },
   {
     "valueCol": "casesAverted",
     "displayName": "Mean cases averted per population per year across 3 yrs since intervention",
+    "error": {
+      "minus": {
+        "valueCol": "casesAvertedErrorMinus"
+      },
+      "plus": {
+        "valueCol": "casesAvertedErrorPlus"
+      }
+    },
     "transform": "round({} / 10) * 10"
   },
   {
     "valueCol": "casesAvertedPer1000",
     "displayName": "Mean cases averted per 1000 people across 3 yrs since intervention",
+    "error": {
+      "minus": {
+        "valueCol": "casesAvertedPer1000ErrorMinus"
+      },
+      "plus": {
+        "valueCol": "casesAvertedPer1000ErrorPlus"
+      }
+    },
     "transform": "round({} / 10) * 10"
   },
   {
     "valueCol": "reductionInCases",
-    "displayName": "Relative reduction in clinical cases across 3 yrs since intervention (%)"
+    "displayName": "Relative reduction in clinical cases across 3 yrs since intervention (%)",
+    "error": {
+      "minus": {
+        "valueCol": "reductionInCasesErrorMinus"
+      },
+      "plus": {
+        "valueCol": "reductionInCasesErrorPlus"
+      }
+    }
   },
   {
     "valueCol": "meanCases",
-    "displayName": "Mean cases per person per year across 3 yrs"
+    "displayName": "Mean cases per person per year across 3 yrs",
+    "error": {
+      "minus": {
+        "valueCol": "meanCasesErrorMinus"
+      },
+      "plus": {
+        "valueCol": "meanCasesErrorPlus"
+      }
+    }
   }
 ]

--- a/inst/json/table_impact_config.json
+++ b/inst/json/table_impact_config.json
@@ -70,7 +70,8 @@
       "plus": {
         "valueCol": "reductionInPrevalenceErrorPlus"
       }
-    }
+    },
+    "format": "0.0"
   },
   {
     "valueCol": "casesAverted",
@@ -108,7 +109,8 @@
       "plus": {
         "valueCol": "reductionInCasesErrorPlus"
       }
-    }
+    },
+    "format": "0.0"
   },
   {
     "valueCol": "meanCases",
@@ -120,6 +122,7 @@
       "plus": {
         "valueCol": "meanCasesErrorPlus"
       }
-    }
+    },
+    "format": "0.0000"
   }
 ]

--- a/inst/schema/TableDefinition.schema.json
+++ b/inst/schema/TableDefinition.schema.json
@@ -2,6 +2,30 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
   "definitions": {
+    "errorValue": {
+      "type": "object",
+      "properties": {
+        "valueTransform": {
+          "type": "object"
+        },
+        "valueCol": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "required": [
+            "valueTransform"
+          ]
+        },
+        {
+          "required": [
+            "valueCol"
+          ]
+        }
+      ]
+    },
     "columnDefinition": {
       "type": "object",
       "properties": {
@@ -10,8 +34,12 @@
         "error": {
           "type": "object",
           "properties": {
-            "minus": {"type": "object"},
-            "plus": {"type": "object"}
+            "minus": {
+              "$ref": "#/definitions/errorValue"
+            },
+            "plus": {
+              "$ref": "#/definitions/errorValue"
+            }
           },
           "additionalProperties": false,
           "required": ["minus", "plus"]

--- a/inst/schema/TableDefinition.schema.json
+++ b/inst/schema/TableDefinition.schema.json
@@ -7,6 +7,15 @@
       "properties": {
         "valueCol": {"type": "string"},
         "displayName": {"type": "string"},
+        "error": {
+          "type": "object",
+          "properties": {
+            "minus": {"type": "object"},
+            "plus": {"type": "object"}
+          },
+          "additionalProperties": false,
+          "required": ["minus", "plus"]
+        },
         "valueTransform": {"type": "object"},
         "transform": {"type": "string"},
         "format": {"type": "string"},

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -210,6 +210,14 @@ test_that("impact table config contains valid intervention ids", {
 
 })
 
+test_that("impact table config formulas give correct results for cases averted", {
+  json <- jsonlite::fromJSON(mintr_path("json/table_impact_config.json"))
+  input <- get_input()
+  expect_equal(input$casesAverted, input[[json$valueCol[8]]])
+  expect_equal(input$casesAvertedErrorPlus, input[[json$error$plus$valueCol[8]]])
+  expect_equal(input$casesAvertedErrorMinus, input[[json$error$minus$valueCol[8]]])
+})
+
 test_that("cost table config contains valid intervention ids", {
   json <- jsonlite::fromJSON(mintr_path("json/table_cost_config.json"))
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -273,7 +273,7 @@ validate_costs_per_cases_averted <- function(formulas, costs) {
 
 test_that("cost table config formulas give correct results for costs per cases averted", {
   json <- jsonlite::fromJSON(mintr_path("json/table_cost_config.json"))
-  validate_costs_per_cases_averted(json$valueTransform[7,], get_costs_per_cases_averted("casesAverted"))
-  validate_costs_per_cases_averted(json$error$plus$valueTransform[7,], get_costs_per_cases_averted("casesAvertedErrorMinus"))
-  validate_costs_per_cases_averted(json$error$minus$valueTransform[7,], get_costs_per_cases_averted("casesAvertedErrorPlus"))
+  validate_costs_per_cases_averted(json$valueTransform[6,], get_costs_per_cases_averted("casesAverted"))
+  validate_costs_per_cases_averted(json$error$plus$valueTransform[6,], get_costs_per_cases_averted("casesAvertedErrorMinus"))
+  validate_costs_per_cases_averted(json$error$minus$valueTransform[6,], get_costs_per_cases_averted("casesAvertedErrorPlus"))
 })

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -46,12 +46,15 @@ test_that("Can read table data", {
   expect_equal(nrow(d), 114)
   expect_setequal(
     names(d),
-    c("netUse", "irsUse", "intervention", "prevYear1",
-      "prevYear2", "prevYear3", "meanCases", "reductionInCases",
-      "reductionInPrevalence", "casesAverted",
-      "casesAvertedPer1000", "casesAvertedPer1000ErrorMinus",
-      "casesAvertedPer1000ErrorPlus", "reductionInCasesErrorMinus",
-      "reductionInCasesErrorPlus"))
+    c("netUse", "irsUse", "intervention",
+      "casesAverted", "casesAvertedErrorMinus", "casesAvertedErrorPlus",
+      "casesAvertedPer1000", "casesAvertedPer1000ErrorMinus", "casesAvertedPer1000ErrorPlus",
+      "prevYear1", "prevYear1ErrorMinus", "prevYear1ErrorPlus",
+      "prevYear2", "prevYear2ErrorMinus", "prevYear2ErrorPlus",
+      "prevYear3", "prevYear3ErrorMinus", "prevYear3ErrorPlus",
+      "reductionInPrevalence", "reductionInPrevalenceErrorMinus", "reductionInPrevalenceErrorPlus",
+      "reductionInCases", "reductionInCasesErrorMinus", "reductionInCasesErrorPlus",
+      "meanCases", "meanCasesErrorMinus", "meanCasesErrorPlus"))
 })
 
 
@@ -165,7 +168,7 @@ test_that("Can scale table results by population", {
   d1 <- db$get_table(options)
   d2 <- db$get_table(modifyList(options, list(population = 1000)))
 
-  v <- setdiff(names(d1), "casesAverted")
+  v <- setdiff(names(d1), c("casesAverted", "casesAvertedErrorMinus", "casesAvertedErrorPlus"))
   expect_equal(d2[v], d1[v])
   ## Due to rounding error, this is only approximate
   expect_equal(d2$casesAverted, d1$casesAverted / 10,


### PR DESCRIPTION
See mrc-ide/mint#80

This has been implemented by allowing for arbitrary fields in an `error` field that are merged into the top-level column definition in order to calculate the upper and lower bounds. In this case they replace the `valueCol` or `valueTransform` fields.

A simpler alternative would be to simply specify substitutions, which would be agnostic of whether the top-level was using `valueCol` or `valueTransform`. This is be less flexible: it wouldn't cater for the (unlikely?) case where calculating an upper or lower bound required a different formula to the mean value. I'd welcome thoughts on this. Would look something like this:
```json
    "error": {
      "minus": {
        "casesAvertedPer1000": "casesAvertedPer1000ErrorMinus"
      },
      "plus": {
        "casesAvertedPer1000": "casesAvertedPer1000ErrorPlus"
      }
    }
```