### PR TITLE
mrc-2083 Investigate non-zero cost when no intervention

### DIFF
--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -8,7 +8,7 @@
           "series": [
               {
                   "id": "none",
-                  "y_formula": ["({population} / {procurePeoplePerNet}) * {priceNetStandard}"],
+                  "y_formula": ["0"],
                   "name": "No intervention",
                   "type": "scatter",
                   "marker": {"color": "grey", "size": 10},
@@ -21,7 +21,7 @@
               },
               {
                   "id": "llin",
-                  "y_formula": ["({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100))"],
+                  "y_formula": ["({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
                   "name": "Pyrethroid LLIN only",
                   "type": "scatter",
                   "marker": {"color": "blue", "size": 10},
@@ -34,7 +34,7 @@
               },
               {
                   "id": "llin-pbo",
-                  "y_formula": ["({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100))"],
+                  "y_formula": ["({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
                   "name": "Pyrethroid-PBO ITN only",
                   "type": "scatter",
                   "marker": {"color": "turquoise", "size": 10},
@@ -47,7 +47,7 @@
               },
               {
                   "id": "irs",
-                  "y_formula": ["({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population})"],
+                  "y_formula": ["3 * {priceIRSPerPerson} * {population}"],
                   "name": "IRS only",
                   "type": "scatter",
                   "marker": {"color": "purple", "size": 10},
@@ -60,7 +60,7 @@
               },
               {
                   "id": "irs-llin",
-                  "y_formula": ["({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})"],
+                  "y_formula": ["({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}"],
                   "name": "Pyrethroid LLIN with IRS",
                   "type": "scatter",
                   "marker": {"color": "darkred", "size": 10},
@@ -73,7 +73,7 @@
               },
               {
                   "id": "irs-llin-pbo",
-                  "y_formula": ["({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})"],
+                  "y_formula": ["({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}"],
                   "name": "Pyrethroid-PBO ITN with IRS",
                   "type": "scatter",
                   "marker": {"color": "orange", "size": 10},

--- a/inst/json/graph_cost_per_case_config.json
+++ b/inst/json/graph_cost_per_case_config.json
@@ -8,7 +8,7 @@
         {
             "x": ["llin"],
             "id": "llin",
-            "y_formula": ["(({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100))) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}"],
             "type": "bar",
             "name": "Pyrethroid LLIN only",
             "marker": {
@@ -19,7 +19,7 @@
         {
             "x": ["llin-pbo"],
             "id": "llin-pbo",
-            "y_formula": ["(({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100))) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}"],
             "type": "bar",
             "name": "Pyrethroid-PBO ITN only",
             "marker": {
@@ -30,7 +30,7 @@
         {
             "x": ["irs"],
             "id": "irs",
-            "y_formula": ["(({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population})) / {casesAverted}"],
+            "y_formula": ["(3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
             "name": "IRS only",
             "type": "bar",
             "marker": {
@@ -41,7 +41,7 @@
         {
             "x": ["irs-llin"],
             "id": "irs-llin",
-            "y_formula": ["(({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
             "name": "Pyrethroid LLIN with IRS",
             "type": "bar",
             "marker": {
@@ -52,7 +52,7 @@
         {
             "x": ["irs-llin-pbo"],
             "id": "irs-llin-pbo",
-            "y_formula": ["(({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
             "name": "Pyrethroid-PBO ITN with IRS",
             "type": "bar",
             "marker": {

--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -30,12 +30,12 @@
     "valueCol": "intervention",
     "displayName": "Total costs",
     "valueTransform": {
-      "none": "({population} / {procurePeoplePerNet}) * {priceNetStandard}",
-      "llin": "({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100))",
-      "llin-pbo": "({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100))",
-      "irs": "({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population})",
-      "irs-llin": "({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})",
-      "irs-llin-pbo": "({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})"
+      "none": "0",
+      "llin": "({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100",
+      "llin-pbo": "({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100",
+      "irs": "3 * {priceIRSPerPerson} * {population}",
+      "irs-llin": "({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}",
+      "irs-llin-pbo": "({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}"
     },
     "format": "$0[.][00]a",
     "precision": 4
@@ -45,11 +45,11 @@
     "displayName": "Incremental increase in costs",
     "valueTransform": {
       "none": "0",
-      "llin": "({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)) - (({population} / {procurePeoplePerNet}) * {priceNetStandard})",
-      "llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100))) - (({population} / {procurePeoplePerNet}) * {priceNetStandard})",
-      "irs": "({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population}) - (({population} / {procurePeoplePerNet}) * {priceNetStandard})",
-      "irs-llin": "({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}) - (({population} / {procurePeoplePerNet}) * {priceNetStandard})",
-      "irs-llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population})) - (({population} / {procurePeoplePerNet}) * {priceNetStandard})"
+      "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) - 0",
+      "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) - 0",
+      "irs": "(3 * {priceIRSPerPerson} * {population}) - 0",
+      "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) - 0",
+      "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) - 0"
     },
     "format": "$0[.][00]a",
     "precision": 4
@@ -59,11 +59,11 @@
     "displayName": "Cost per case averted per 3-year campaign",
     "valueTransform": {
       "none": "'reference'",
-      "llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",
-      "llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO}  + ({priceDelivery} * {population} * (({procureBuffer} + 100)/ 100)))/{casesAverted}",
-      "irs": "(({population} / {procurePeoplePerNet}) * {priceNetStandard} + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}",
-      "irs-llin": "(({population} / {procurePeoplePerNet}) * {priceNetStandard} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}",
-      "irs-llin-pbo": "(({population} / {procurePeoplePerNet}) * {priceNetPBO} + ({priceDelivery} * {population} * (({procureBuffer} + 100) / 100)) + 3 * ({priceIRSPerPerson} * {population}))/{casesAverted}"
+      "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}",
+      "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}",
+      "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
+      "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
+      "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"
     },
     "transform": "round({} * 10) / 10",
     "format": "$0.00"

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -15,31 +15,21 @@ get_input <- function() {
 get_expected_total_costs <- function() {
   input <- get_input()
 
-  # setting these variables up to be as similar as possible to Ellie's original code
-  # https://github.com/mrc-ide/shiny-malaria-UI/blob/master/server.R#L1148
-  # for verification of correctness
+  # setting these variables up to be as similar as possible to guidance
+  # https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2083
   population <- input$population
   procurement_buffer <- (input$procureBuffer + 100) / 100
-  cost_per_N0 <- input$priceNetStandard
   cost_per_N1 <- input$priceNetStandard
   cost_per_N2 <- input$priceNetPBO
-  price_NET_delivery <- input$priceDelivery *
-    population *
-    procurement_buffer
+  price_NET_delivery <- input$priceDelivery
   price_IRS_delivery <- input$priceIRSPerPerson * population
 
-  costs_N0 <- cost_per_N0 * (population / input$procurePeoplePerNet) + 0
-  costs_N1 <- cost_per_N1 * (population / input$procurePeoplePerNet) + price_NET_delivery
-  costs_N2 <- cost_per_N2 * (population / input$procurePeoplePerNet) + price_NET_delivery
-  costs_S1 <- cost_per_N0 * (population / input$procurePeoplePerNet) +
-    0 +
-    3 * price_IRS_delivery
-  costs_N1_S1 <- cost_per_N1 * (population / input$procurePeoplePerNet) +
-    price_NET_delivery +
-    3 * price_IRS_delivery
-  costs_N2_S1 <- cost_per_N2 * (population / input$procurePeoplePerNet) +
-    price_NET_delivery +
-    3 * price_IRS_delivery
+  costs_N0 <- 0
+  costs_N1 <- (price_NET_delivery + cost_per_N1) * (population / input$procurePeoplePerNet * procurement_buffer)
+  costs_N2 <- (price_NET_delivery + cost_per_N2) * (population / input$procurePeoplePerNet * procurement_buffer)
+  costs_S1 <- 3 * price_IRS_delivery
+  costs_N1_S1 <- costs_N1 + costs_S1
+  costs_N2_S1 <- costs_N2 + costs_S1
 
   list(costs_N0 = costs_N0,
        costs_N1 = costs_N1,


### PR DESCRIPTION
Update cost formulae (and code used to verify) to match [guidance provided by Ellie](https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2083#focus=Comments-97-11582.0-0). This results in zero cost when no intervention is made but also changes the other figures as a result of applying the procurement buffer to the cost of buying nets rather than just to their delivery as previously. This is clearly specified in the `Economic analysis.docx` document attached to mrc-2083.

Note that the "Incremental increase in costs" column on the Cost effectiveness tab is now effectively redundant, given that with a zero baseline it now always matches "Total costs". This will be discussed at the next meeting and a new ticket created if necessary.