### PR TITLE
mrc-2100 Round cases averted to nearest 10, costs to nearest $0.10 in graphs

### DIFF
--- a/inst/json/graph_cases_averted_config.json
+++ b/inst/json/graph_cases_averted_config.json
@@ -9,6 +9,7 @@
         {
             "x": ["llin"],
             "id": "llin",
+            "y_formula": ["round({casesAvertedPer1000} / 10) * 10"],
             "type": "bar",
             "name": "Pyrethroid LLIN only",
             "marker": {
@@ -17,8 +18,8 @@
             },
             "error_y": {
                 "type": "data",
-                "cols": ["casesAvertedPer1000ErrorPlus"],
-                "colsminus": ["casesAvertedPer1000ErrorMinus"],
+                "cols": ["round({casesAvertedPer1000ErrorPlus} / 10) * 10"],
+                "colsminus": ["round({casesAvertedPer1000ErrorMinus} / 10) * 10"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -28,6 +29,7 @@
         {
             "x": ["llin-pbo"],
             "id": "llin-pbo",
+            "y_formula": ["round({casesAvertedPer1000} / 10) * 10"],
             "type": "bar",
             "name": "Pyrethroid-PBO ITN only",
             "marker": {
@@ -36,8 +38,8 @@
             },
             "error_y": {
                 "type": "data",
-                "cols": ["casesAvertedPer1000ErrorPlus"],
-                "colsminus": ["casesAvertedPer1000ErrorMinus"],
+                "cols": ["round({casesAvertedPer1000ErrorPlus} / 10) * 10"],
+                "colsminus": ["round({casesAvertedPer1000ErrorMinus} / 10) * 10"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -47,6 +49,7 @@
         {
             "x": ["irs"],
             "id": "irs",
+            "y_formula": ["round({casesAvertedPer1000} / 10) * 10"],
             "name": "IRS only",
             "type": "bar",
             "marker": {
@@ -55,8 +58,8 @@
             },
             "error_y": {
                 "type": "data",
-                "cols": ["casesAvertedPer1000ErrorPlus"],
-                "colsminus": ["casesAvertedPer1000ErrorMinus"],
+                "cols": ["round({casesAvertedPer1000ErrorPlus} / 10) * 10"],
+                "colsminus": ["round({casesAvertedPer1000ErrorMinus} / 10) * 10"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -66,6 +69,7 @@
         {
             "x": ["irs-llin"],
             "id": "irs-llin",
+            "y_formula": ["round({casesAvertedPer1000} / 10) * 10"],
             "name": "Pyrethroid LLIN with IRS",
             "type": "bar",
             "marker": {
@@ -74,8 +78,8 @@
             },
             "error_y": {
                 "type": "data",
-                "cols": ["casesAvertedPer1000ErrorPlus"],
-                "colsminus": ["casesAvertedPer1000ErrorMinus"],
+                "cols": ["round({casesAvertedPer1000ErrorPlus} / 10) * 10"],
+                "colsminus": ["round({casesAvertedPer1000ErrorMinus} / 10) * 10"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -85,6 +89,7 @@
         {
             "x": ["irs-llin-pbo"],
             "id": "irs-llin-pbo",
+            "y_formula": ["round({casesAvertedPer1000} / 10) * 10"],
             "name": "Pyrethroid-PBO ITN with IRS",
             "type": "bar",
             "marker": {
@@ -93,8 +98,8 @@
             },
             "error_y": {
                 "type": "data",
-                "cols": ["casesAvertedPer1000ErrorPlus"],
-                "colsminus": ["casesAvertedPer1000ErrorMinus"],
+                "cols": ["round({casesAvertedPer1000ErrorPlus} / 10) * 10"],
+                "colsminus": ["round({casesAvertedPer1000ErrorMinus} / 10) * 10"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,

--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -12,6 +12,7 @@
                   "name": "No intervention",
                   "type": "scatter",
                   "marker": {"color": "grey", "size": 10},
+                  "hovertemplate": "%{x}, $%{y:.3s}",
                   "error_x": {
                       "type": "data",
                       "width": 0,
@@ -25,6 +26,7 @@
                   "name": "Pyrethroid LLIN only",
                   "type": "scatter",
                   "marker": {"color": "blue", "size": 10},
+                  "hovertemplate": "%{x}, $%{y:.3s}",
                   "error_x": {
                       "type": "data",
                       "width": 0,
@@ -38,6 +40,7 @@
                   "name": "Pyrethroid-PBO ITN only",
                   "type": "scatter",
                   "marker": {"color": "turquoise", "size": 10},
+                  "hovertemplate": "%{x}, $%{y:.3s}",
                   "error_x": {
                       "type": "data",
                       "width": 0,
@@ -51,6 +54,7 @@
                   "name": "IRS only",
                   "type": "scatter",
                   "marker": {"color": "purple", "size": 10},
+                  "hovertemplate": "%{x}, $%{y:.3s}",
                   "error_x": {
                       "type": "data",
                       "width": 0,
@@ -64,6 +68,7 @@
                   "name": "Pyrethroid LLIN with IRS",
                   "type": "scatter",
                   "marker": {"color": "darkred", "size": 10},
+                  "hovertemplate": "%{x}, $%{y:.3s}",
                   "error_x": {
                       "type": "data",
                       "width": 0,
@@ -77,6 +82,7 @@
                   "name": "Pyrethroid-PBO ITN with IRS",
                   "type": "scatter",
                   "marker": {"color": "orange", "size": 10},
+                  "hovertemplate": "%{x}, $%{y:.3s}",
                   "error_x": {
                       "type": "data",
                       "width": 0,

--- a/inst/json/graph_cost_per_case_config.json
+++ b/inst/json/graph_cost_per_case_config.json
@@ -15,6 +15,7 @@
                 "color": "blue",
                 "opacity": 0.5
             },
+            "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
                 "cols": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}"],
@@ -35,6 +36,7 @@
                 "color": "aquamarine",
                 "opacity": 0.5
             },
+            "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
                 "cols": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}"],
@@ -55,6 +57,7 @@
                 "color": "purple",
                 "opacity": 0.5
             },
+            "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
                 "cols": ["(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],
@@ -75,6 +78,7 @@
                 "color": "darkred",
                 "opacity": 0.5
             },
+            "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
                 "cols": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],
@@ -95,6 +99,7 @@
                 "color": "orange",
                 "opacity": 0.5
             },
+            "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
                 "cols": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],

--- a/inst/json/graph_prevalence_config.json
+++ b/inst/json/graph_prevalence_config.json
@@ -28,21 +28,21 @@
             "name": "No intervention",
             "type": "lines",
             "marker": {"color": "grey"},
-            "hovertemplate": "%{y:.2%}"
+            "hovertemplate": "%{y:.1%}"
         },
         {
             "id": "llin",
             "name": "Pyrethroid LLIN only",
             "type": "lines",
             "marker": {"color": "blue"},
-            "hovertemplate": "%{y:.2%}"
+            "hovertemplate": "%{y:.1%}"
         },
         {
             "id": "llin-pbo",
             "name": "Pyrethroid-PBO ITN only",
             "type": "lines",
             "marker": {"color": "turquoise"},
-            "hovertemplate": "%{y:.2%}"
+            "hovertemplate": "%{y:.1%}"
         },
         {
             "id": "irs",
@@ -52,7 +52,7 @@
                 "dash": "dot"
             },
             "marker": {"color": "purple"},
-            "hovertemplate": "%{y:.2%}"
+            "hovertemplate": "%{y:.1%}"
         },
         {
             "id": "irs-llin",
@@ -62,7 +62,7 @@
                 "dash": "dash"
             },
             "marker": {"color": "darkred"},
-            "hovertemplate": "%{y:.2%}"
+            "hovertemplate": "%{y:.1%}"
         },
         {
             "id": "irs-llin-pbo",
@@ -72,7 +72,7 @@
                 "dash": "dash"
             },
             "marker": {"color": "orange"},
-            "hovertemplate": "%{y:.2%}"
+            "hovertemplate": "%{y:.1%}"
         }
     ],
     "config": {


### PR DESCRIPTION
Use Plotly hover templates to display figures to required precision, matching axes and presentation in tables. Use formulae to round cost per figures, as this isn't supported by hover templates.