### PR TITLE
mrc-2087 Rename irs to 'long lasting non-pyrethroid  IRS', and add footnote.

### DIFF
--- a/inst/json/baseline_options.json
+++ b/inst/json/baseline_options.json
@@ -122,7 +122,7 @@
           "controls": [
             {
               "name": "levelOfResistance",
-              "label": "Level of pyrethoid resistance",
+              "label": "Level of pyrethroid resistance",
               "type": "select",
               "excludeNullOption": true,
               "required": true,

--- a/inst/json/intervention_options.json
+++ b/inst/json/intervention_options.json
@@ -32,7 +32,7 @@
                     "controls": [
                         {
                             "name": "irsUse",
-                            "label": "Expected IRS coverage",
+                            "label": "Expected IRS* coverage",
                             "type": "select",
                             "excludeNullOption": true,
                             "required": true,
@@ -51,7 +51,7 @@
                 }
             ],
             "collapsible": true,
-            "documentation": "<strong>Expected ITN population use given access</strong><p>User enters the expected optimal ITN usage among people in the community after the mass distribution campaign. This will determine the intervention efficacy and cost-effectiveness of the campaign. Only one net type is implemented for an intervention zone. We compare which will be most cost effective within budget.</p><strong>Expected IRS coverage</strong><p>Indoor residual spraying can be added to zones instead, or in addition to, ITNs (of any type). Houses to receive IRS are selected at random (irrespective of ITN ownership) and IRS coverage estimates represent the percentage of the population living in houses with IRS. Care should be taken interpreting results as IRS is often highly clustered within a small geographical areas. The model predicts the impact of a long-lasting IRS product (for example Actellic 300CS or Sumishield) where spraying is repeated annually prior to the peak of the transmission season (if seasonal setting selected in baseline inputs).</p>"
+            "documentation": "<strong>Expected ITN population use given access</strong><p>User enters the expected optimal ITN usage among people in the community after the mass distribution campaign. This will determine the intervention efficacy and cost-effectiveness of the campaign. Only one net type is implemented for an intervention zone. We compare which will be most cost effective within budget.</p><strong>Expected IRS* coverage</strong><p>Indoor residual spraying can be added to zones instead, or in addition to, ITNs (of any type). Houses to receive IRS are selected at random (irrespective of ITN ownership) and IRS coverage estimates represent the percentage of the population living in houses with IRS. Care should be taken interpreting results as IRS is often highly clustered within a small geographical areas. The model predicts the impact of a long-lasting IRS product (for example Actellic 300CS or Sumishield) where spraying is repeated annually prior to the peak of the transmission season (if seasonal setting selected in baseline inputs).</p><p><i>*IRS refers to a long-lasting non-pyrethroid IRS product (impact reflects recent pirimiphos methyl and neonicotinoid products).</i></p>"
 
         },
         {
@@ -123,7 +123,7 @@
                     "controls": [
                         {
                             "name": "priceIRSPerPerson",
-                            "label": "Annual cost of IRS per person ($USD)",
+                            "label": "Annual cost of IRS* per person ($USD)",
                             "type": "number",
                             "required": true,
                             "value": 2.5,
@@ -156,7 +156,7 @@
                 }
             ],
             "collapsible": true,
-            "documentation": "<p>The price of different vector control interventions will vary so can be defined by the user in $USD. For simplicity, it is assumed that there is a linear relationship between cost and population coverage, we do not consider inflation in this iteration of the tool.</p><strong>Price of standard ITN ($USD)</strong><p>Price per pyrethroid-only ITN (expected to be replaced every 3-years).</p><strong>Price of Pyrethroid-PBO ITN ($USD)</strong><p>Price per Pyrethroid-PBO ITN (expected to be replaced every 3-years).</p><strong>ITN mass distribution campaign delivery cost per person ($USD)</strong><p>Cost to deliver nets to each person (equivalent for each ITN type). enough nets are provided to match the number of people per net and the procurement buffer.</p><strong>Price of spray product per person (annual $USD)</strong><p>The price per person of long-lasting IRS product averaged for each year. Include the average cost for both the IRS product and implementation of IRS. If different IRS products are used in different years, please average the product costs and provide an annual cost per person protected by IRS (in $USD)</p><strong>Total available budget ($USD)</strong><p>The total available budget to cover the next 3-years, is required to assess the most feasible intervention options across zones. Cost effectivessness can be optimised across zones.</p><strong>Zonal budget ($USD)</strong><p>The decision makers can choose to cap the budget for each zone to some specified maximum. Please enter the budget for this zone.</p>"
+            "documentation": "<p>The price of different vector control interventions will vary so can be defined by the user in $USD. For simplicity, it is assumed that there is a linear relationship between cost and population coverage, we do not consider inflation in this iteration of the tool.</p><strong>Price of standard ITN ($USD)</strong><p>Price per pyrethroid-only ITN (expected to be replaced every 3-years).</p><strong>Price of Pyrethroid-PBO ITN ($USD)</strong><p>Price per Pyrethroid-PBO ITN (expected to be replaced every 3-years).</p><strong>ITN mass distribution campaign delivery cost per person ($USD)</strong><p>Cost to deliver nets to each person (equivalent for each ITN type). enough nets are provided to match the number of people per net and the procurement buffer.</p><strong>Annual cost of IRS* per person ($USD)</strong><p>The price per person of long-lasting IRS product averaged for each year. Include the average cost for both the IRS product and implementation of IRS. If different IRS products are used in different years, please average the product costs and provide an annual cost per person protected by IRS (in $USD)</p><strong>Total available budget ($USD)</strong><p>The total available budget to cover the next 3-years, is required to assess the most feasible intervention options across zones. Cost effectivessness can be optimised across zones.</p><strong>Zonal budget ($USD)</strong><p>The decision makers can choose to cap the budget for each zone to some specified maximum. Please enter the budget for this zone.</p><p><i>*IRS refers to a long-lasting non-pyrethroid IRS product (impact reflects recent pirimiphos methyl and neonicotinoid products).</i></p>"
         }
     ]
 }


### PR DESCRIPTION
For now this justs adds an asterisk to the two places in the settings where "IRS" appears, with the footnote itself appearing in the corresponding "How to use these settings" text. It should at least provide basis for further discussion, and I'll enumerate further options when we come to solicit feedback from the team.