### PR TITLE
mrc-2206 Import new dataset to clip cases averted at zero

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -83,6 +83,9 @@ mintr_db_process <- function(path) {
           meanCases = "cases_per_person_3_years")
   table <- rename(table, unname(tr), names(tr))
 
+  ## Check that all cases_averted values are non-negative (see mrc-2206)
+  stopifnot(table$casesAverted >= 0)
+
   ## At this point casesAverted is really over 3 years and is cases
   ## averted per person. This number can be greater than one as a
   ## person can have more than one case per year. We remove the year

--- a/inst/data.json
+++ b/inst/data.json
@@ -1,10 +1,10 @@
 {
     "root": "https://mrcdata.dide.ic.ac.uk/mint",
-    "directory": "20201217",
+    "directory": "20210313",
     "files": {
-        "index": "data_index_Vector_tool_updated_params_uncertainty_alter_20201217.rds",
-        "prevalence": "data_values_Vector_tool_updated_params_uncertainty_alter_20201217.rds",
-        "table": "data_aggregate_Vector_tool_updated_params_uncertainty_alter_20201217.rds"
+        "index": "data_index_Vector_tool_updated_params_uncertainty_no_zero_20210313.rds",
+        "prevalence": "data_values_Vector_tool_updated_params_uncertainty_no_zero_20210313.rds",
+        "table": "data_aggregate_Vector_tool_updated_params_uncertainty_no_zero_20210313.rds"
     },
     "interventions": {
         "none": "No intervention",


### PR DESCRIPTION
Point at latest dataset, and add a check that cases averted are never negative.

Old (current production system, scenario as in original report from user):

![mint_old](https://user-images.githubusercontent.com/1724545/112146142-1fa1f480-8bd3-11eb-82a8-4bcd1f6751ae.png)

New:

![mint_new](https://user-images.githubusercontent.com/1724545/112146156-23ce1200-8bd3-11eb-99e8-9811e9ebf5d0.png)
