### PR TITLE
mrc-2433 Add endpoint for strategizing across regions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Imports:
     rmpk,
     ROIoptimzer,
     ROI.plugin.glpk,
-    thor
+    thor,
+    tidyr
 Suggests:
     glue,
     jsonvalidate (>= 1.2.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     rmpk,
     ROIoptimzer,
     ROI.plugin.glpk,
-    tidyr,
     thor
 Suggests:
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     rmpk,
     ROIoptimzer,
     ROI.plugin.glpk,
+    tidyr,
     thor
 Suggests:
     glue,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,4 +2,3 @@
 
 import(ROI.plugin.glpk)
 import(dplyr)
-import(tidyr)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,3 +2,4 @@
 
 import(ROI.plugin.glpk)
 import(dplyr)
+import(tidyr)

--- a/R/api.R
+++ b/R/api.R
@@ -18,6 +18,7 @@ api_build <- function(db) {
   pr$handle(endpoint_graph_cases_averted_config())
   pr$handle(endpoint_impact_intepretation(db))
   pr$handle(endpoint_cost_intepretation(db))
+  pr$handle(endpoint_strategise(db))
   pr
 }
 
@@ -218,3 +219,21 @@ target_cost_interpretation <- function(db) {
   }
 }
 
+endpoint_strategise <- function(db) {
+  root <- schema_root()
+  porcelain::porcelain_endpoint$new(
+    "POST", "/strategise",
+    target_strategise(db),
+    porcelain::porcelain_input_body_json("json", "StrategiseOptions.schema", root),
+    returning = porcelain::porcelain_returning_json("Strategise.schema", root))
+}
+
+target_strategise <- function(db) {
+  force(db)
+  function(json) {
+    jsonlite::toJSON(
+      strategise(jsonlite::fromJSON(json, simplifyVector=FALSE), db),
+      auto_unbox=TRUE
+    )
+  }
+}

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -1,5 +1,9 @@
+#' @import tidyr
 #' @import dplyr
 do_optimise <- function(data, budget) {
+  # rmpk requires an equal number of scenarios for each zone, so we add missing
+  # combinations ensuring that they are less attractive than no intervention
+  data <- complete(data, zone, intervention, fill = list(cost = max(data$cost), cases_averted = 0))
   zone <- intervention <- cost <- cases_averted <- i <- j <- NULL # used by dplyr
   cost_df <- distinct(data, zone, intervention, cost) %>%
     group_by(intervention) %>%

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -1,23 +1,37 @@
 #' @import dplyr
+#' @import tidyr
 do_optimise <- function(data, budget) {
-  zone <- intervention <- total_costs <- total_cases_averted <- i <- j <- NULL # used by dplyr
-  cost_df <- distinct(data, zone, intervention, total_costs) %>%
+  zone <- intervention <- cost <- cases_averted <- i <- j <- NULL # used by dplyr
+
+  # Due to a limitation in the optimiser it currently requires at least two
+  # scenarios with non-zero cases_averted - this workaround therefore adds two
+  # dummy scenarios, with budget-exceeding costs to ensure they are not selected
+  data <- bind_rows(data,
+      distinct(data, zone) %>%
+        crossing(data.frame(
+          intervention = c("dummy_1", "dummy_2"),
+          cost = rep(budget * 10 + 1, 2),
+          cases_averted = rep(1, 2)
+        ))
+  )
+
+  cost_df <- distinct(data, zone, intervention, cost) %>%
     group_by(intervention) %>%
     mutate(j = cur_group_id()) %>%
     group_by(zone) %>%
     mutate(i = cur_group_id()) %>%
     ungroup()
-  cases_av_df <- distinct(data, zone, intervention, total_cases_averted) %>%
+  cases_av_df <- distinct(data, zone, intervention, cases_averted) %>%
     group_by(intervention) %>%
     mutate(j = cur_group_id()) %>%
     group_by(zone) %>%
     mutate(i = cur_group_id()) %>%
     ungroup()
   cost <- function(zone, intervention) {
-    filter(cost_df, i == !!zone, j == !!intervention)$total_costs
+    filter(cost_df, i == !!zone, j == !!intervention)$cost
   }
   cases_av <- function(zone, intervention) {
-    filter(cases_av_df, i == !!zone, j == !!intervention)$total_cases_averted
+    filter(cases_av_df, i == !!zone, j == !!intervention)$cases_averted
   }
   n_zones <- n_distinct(data$zone)
   n_interventions <- n_distinct(data$intervention)
@@ -34,10 +48,10 @@ do_optimise <- function(data, budget) {
     model$get_variable_value(y[i, j]) %>%
       filter(value == 1) %>%
       left_join(cost_df, c("i", "j")) %>%
-      left_join(select(cases_av_df, total_cases_averted, i, j), by = c("i", "j"))
+      left_join(select(cases_av_df, cases_averted, i, j), by = c("i", "j"))
   }
 
   optimise(budget) %>%
-    select(zone, intervention, total_costs, total_cases_averted) %>%
+    select(zone, intervention, cost, cases_averted) %>%
     arrange(zone)
 }

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -2,19 +2,6 @@
 #' @import tidyr
 do_optimise <- function(data, budget) {
   zone <- intervention <- cost <- cases_averted <- i <- j <- NULL # used by dplyr
-
-  # Due to a limitation in the optimiser it currently requires at least two
-  # scenarios with non-zero cases_averted - this workaround therefore adds two
-  # dummy scenarios, with budget-exceeding costs to ensure they are not selected
-  data <- bind_rows(data,
-      distinct(data, zone) %>%
-        crossing(data.frame(
-          intervention = c("dummy_1", "dummy_2"),
-          cost = rep(budget * 10 + 1, 2),
-          cases_averted = rep(1, 2)
-        ))
-  )
-
   cost_df <- distinct(data, zone, intervention, cost) %>%
     group_by(intervention) %>%
     mutate(j = cur_group_id()) %>%
@@ -42,7 +29,11 @@ do_optimise <- function(data, budget) {
     model <- rmpk::optimization_model(rmpk::ROI_optimizer("glpk"))
     y <- model$add_variable("y", i = 1:n_zones, j = 1:n_interventions, type = "integer", lb = 0, ub = 1)
     model$set_objective(rmpk::sum_expr(y[i, j] * cases_av(i, j), i = 1:n_zones, j = 1:n_interventions), sense = "max")
-    model$add_constraint(rmpk::sum_expr(y[i, j] * cost(i, j), i = 1:n_zones, j = 1:n_interventions) <= budget)
+    # rmpk currently fails if all scenarios have zero cost. work around this by
+    # only constraining costs if some non-zero cost scenarios are provided.
+    if (n_interventions > 1) {
+      model$add_constraint(rmpk::sum_expr(y[i, j] * cost(i, j), i = 1:n_zones, j = 1:n_interventions) <= budget)
+    }
     model$add_constraint(rmpk::sum_expr(y[i, j], j = 1:n_interventions) == 1, i = 1:n_zones)
     model$optimize()
     model$get_variable_value(y[i, j]) %>%

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -1,5 +1,4 @@
 #' @import dplyr
-#' @import tidyr
 do_optimise <- function(data, budget) {
   zone <- intervention <- cost <- cases_averted <- i <- j <- NULL # used by dplyr
   cost_df <- distinct(data, zone, intervention, cost) %>%

--- a/R/strategise.R
+++ b/R/strategise.R
@@ -2,26 +2,19 @@ strategise <- function(options, db) {
   cost <- function(baseline_settings, intervention_settings, intervention) {
     population <- baseline_settings$population
     procurement_buffer <- (intervention_settings$procureBuffer + 100) / 100
-    cost_per_N1 <- intervention_settings$priceNetStandard
-    cost_per_N2 <- intervention_settings$priceNetPBO
-    price_NET_delivery <- intervention_settings$priceDelivery
-    price_IRS_delivery <- intervention_settings$priceIRSPerPerson * population
-
-    costs_N0 <- 0
-    costs_N1 <- (price_NET_delivery + cost_per_N1) * (population / intervention_settings$procurePeoplePerNet * procurement_buffer)
-    costs_N2 <- (price_NET_delivery + cost_per_N2) * (population / intervention_settings$procurePeoplePerNet * procurement_buffer)
-    costs_S1 <- 3 * price_IRS_delivery
-    costs_N1_S1 <- costs_N1 + costs_S1
-    costs_N2_S1 <- costs_N2 + costs_S1
-
+    cost_per_net_llin <- intervention_settings$priceNetStandard
+    cost_per_net_pbo <- intervention_settings$priceNetPBO
+    cost_delivery_per_net <- intervention_settings$priceDelivery
+    people_per_net <- intervention_settings$procurePeoplePerNet
+    cost_irs_per_person <- intervention_settings$priceIRSPerPerson
     switch(
       intervention,
-      "none" = costs_N0,
-      "llin" = costs_N1,
-      "llin-pbo" = costs_N2,
-      "irs" = costs_S1,
-      "irs-llin" = costs_N1_S1,
-      "irs-llin-pbo" = costs_N2_S1
+      "none" = 0,
+      "llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer),
+      "llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer),
+      "irs" = 3 * cost_irs_per_person * population,
+      "irs-llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population,
+      "irs-llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population
     )
   }
 

--- a/R/strategise.R
+++ b/R/strategise.R
@@ -1,23 +1,23 @@
-strategise <- function(options, db) {
-  cost <- function(baseline_settings, intervention_settings, intervention) {
-    population <- baseline_settings$population
-    procurement_buffer <- (intervention_settings$procureBuffer + 100) / 100
-    cost_per_net_llin <- intervention_settings$priceNetStandard
-    cost_per_net_pbo <- intervention_settings$priceNetPBO
-    cost_delivery_per_net <- intervention_settings$priceDelivery
-    people_per_net <- intervention_settings$procurePeoplePerNet
-    cost_irs_per_person <- intervention_settings$priceIRSPerPerson
-    switch(
-      intervention,
-      "none" = 0,
-      "llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer),
-      "llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer),
-      "irs" = 3 * cost_irs_per_person * population,
-      "irs-llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population,
-      "irs-llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population
-    )
-  }
+cost <- function(baseline_settings, intervention_settings, intervention) {
+  population <- baseline_settings$population
+  procurement_buffer <- (intervention_settings$procureBuffer + 100) / 100
+  cost_per_net_llin <- intervention_settings$priceNetStandard
+  cost_per_net_pbo <- intervention_settings$priceNetPBO
+  cost_delivery_per_net <- intervention_settings$priceDelivery
+  people_per_net <- intervention_settings$procurePeoplePerNet
+  cost_irs_per_person <- intervention_settings$priceIRSPerPerson
+  switch(
+    intervention,
+    "none" = 0,
+    "llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer),
+    "llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer),
+    "irs" = 3 * cost_irs_per_person * population,
+    "irs-llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population,
+    "irs-llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population
+  )
+}
 
+strategise <- function(options, db) {
   cases_averted <- function(baseline_settings, intervention_settings, intervention) {
     table <- db$get_table(baseline_settings)
     switch(

--- a/R/strategise.R
+++ b/R/strategise.R
@@ -1,4 +1,4 @@
-cost <- function(baseline_settings, intervention_settings, intervention) {
+get_cost <- function(baseline_settings, intervention_settings, intervention) {
   population <- baseline_settings$population
   procurement_buffer <- (intervention_settings$procureBuffer + 100) / 100
   cost_per_net_llin <- intervention_settings$priceNetStandard
@@ -17,97 +17,65 @@ cost <- function(baseline_settings, intervention_settings, intervention) {
   )
 }
 
-strategise <- function(options, db) {
-  cases_averted <- function(baseline_settings, intervention_settings, intervention) {
-    table <- db$get_table(baseline_settings)
-    switch(
-      intervention,
-      "none" = subset(
-        table,
-        intervention == "none"
-      ),
-      "llin" = subset(
-        table,
-        intervention == "llin"
-          & netUse == intervention_settings$netUse
-          & irsUse == "n/a"
-      ),
-      "llin-pbo" =
-        subset(
-          table,
-          intervention == "llin-pbo"
-            & netUse == intervention_settings$netUse
-            & irsUse == "n/a"
-        ),
-      "irs" = subset(
-        table,
-        intervention == "irs"
-          & netUse == "n/a"
-          & irsUse == intervention_settings$irsUse
-      ),
-      "irs-llin" = subset(
-        table,
-        intervention == "irs-llin"
-          & netUse == intervention_settings$netUse
-          & irsUse == intervention_settings$irsUse
-      ),
-      "irs-llin-pbo" = subset(
-        table,
-        intervention == "irs-llin-pbo"
-          & netUse == intervention_settings$netUse
-          & irsUse == intervention_settings$irsUse
-      )
-    )$casesAverted
+get_intervention_data <- function(baseline_settings, intervention_settings, db) {
+  table <- db$get_table(baseline_settings)
+  rows <- table$intervention == "none"
+  if (intervention_settings$netUse != "0") {
+    rows <- rows | (
+      table$intervention %in% c("llin", "llin-pbo") &
+      table$netUse == intervention_settings$netUse &
+      table$irsUse == "n/a"
+    )
   }
+  if (intervention_settings$irsUse != "0") {
+    rows <- rows | (
+      table$intervention == "irs" &
+      table$netUse == "n/a" &
+      table$irsUse == intervention_settings$irsUse
+    )
+  }
+  if (intervention_settings$netUse != "0"
+    && intervention_settings$irsUse != "0") {
+    rows <- rows | (
+      table$intervention %in% c("irs-llin", "irs-llin-pbo") &
+      table$netUse == intervention_settings$netUse &
+      table$irsUse == intervention_settings$irsUse
+    )
+  }
+  table <- table[rows, c("intervention", "casesAverted")]
+  colnames(table) <- c("intervention", "cases_averted")
+  table
+}
 
-  data <- data.frame(
-    zone=character(),
-    intervention=character(),
-    cost=numeric(),
-    cases_averted=numeric()
-  )
-  for (zone in options$zones) {
-    interventions <- c("none")
-    if (zone$interventionSettings$netUse != "0") {
-      interventions <- append(interventions, c("llin", "llin-pbo"))
-    }
-    if (zone$interventionSettings$irsUse != "0") {
-      interventions <- append(interventions, c("irs"))
-    }
-    if (zone$interventionSettings$netUse != "0"
-      && zone$interventionSettings$irsUse != "0") {
-      interventions <- append(interventions, c("irs-llin", "irs-llin-pbo"))
-    }
-    for (intervention in interventions) {
-      data <- rbind(data, data.frame(
-        zone = zone$name,
-        intervention = intervention,
-        cost = cost(
-          zone$baselineSettings,
-          zone$interventionSettings,
-          intervention
-        ),
-        cases_averted = cases_averted(
-          zone$baselineSettings,
-          zone$interventionSettings,
-          intervention
-        )
-      ))
-    }
-  }
-  Map(
-    function(cost_threshold) {
-      budget <- options$budget * cost_threshold
-      res <- do_optimise(data, budget)
-      list(
-        costThreshold = cost_threshold,
-        strategy = list(
-          cost = sum(res$cost),
-          casesAverted = sum(res$cases_averted),
-          interventions = res[c("zone", "intervention")]
-        )
+get_cost_data <- function(baseline_settings, intervention_settings, interventions) {
+  costs <- lapply(interventions, function(intervention) {
+    cost <- get_cost(baseline_settings, intervention_settings, intervention)
+    list(intervention = intervention, cost = cost)
+  })
+  do.call(rbind.data.frame, costs)
+}
+
+strategise <- function(options, db) {
+  data <- lapply(options$zones, function(zone) {
+    data <- get_intervention_data(zone$baselineSettings,
+                                  zone$interventionSettings, db)
+    cost <- get_cost_data(zone$baselineSettings, zone$interventionSettings,
+                      unique(data$intervention))
+    data <- merge(data, cost, by = "intervention", sort = FALSE)
+    data$zone <- zone$name
+    data
+  })
+  data <- do.call(rbind, data)
+  lapply(c(1, 0.95, 0.9, 0.85, 0.8), function(cost_threshold) {
+    budget <- options$budget * cost_threshold
+    res <- do_optimise(data, budget)
+    list(
+      costThreshold = cost_threshold,
+      strategy = list(
+        cost = sum(res$cost),
+        casesAverted = sum(res$cases_averted),
+        interventions = res[c("zone", "intervention")]
       )
-    },
-    c(1, 0.95, 0.9, 0.85, 0.8)
-  )
+    )
+  })
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN install2.r --error \
         remotes \
         testthat \
         thor \
+        tidyr \
         dplyr \
         ROI.plugin.glpk
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN install2.r --error \
         testthat \
         thor \
         dplyr \
+        tidyr \
         ROI.plugin.glpk
 
 RUN installGithub.r \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,6 @@ RUN install2.r --error \
         testthat \
         thor \
         dplyr \
-        tidyr \
         ROI.plugin.glpk
 
 RUN installGithub.r \

--- a/inst/schema/Strategise.schema.json
+++ b/inst/schema/Strategise.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "costThreshold": {
+          "type": "number"
+        },
+        "strategy": {
+          "type": "object",
+          "properties": {
+            "cost": {
+              "type": "number"
+            },
+            "casesAverted": {
+              "type": "number"
+            },
+            "interventions": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "zone": {
+                      "type": "string"
+                    },
+                    "intervention": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "zone",
+                    "intervention"
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "cost",
+            "casesAverted",
+            "interventions"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "costThreshold",
+        "strategy"
+      ]
+    }
+  ]
+}

--- a/inst/schema/StrategiseOptions.schema.json
+++ b/inst/schema/StrategiseOptions.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "budget": {
+      "type": "number"
+    },
+    "zones": {
+      "type": "array",
+      "minItems": 1,
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "baselineSettings": {
+              "type": "object",
+              "properties": {
+                "population": {
+                  "type": "integer"
+                },
+                "seasonalityOfTransmission": {
+                  "type": "string"
+                },
+                "currentPrevalence": {
+                  "type": "string"
+                },
+                "bitingIndoors": {
+                  "type": "string"
+                },
+                "bitingPeople": {
+                  "type": "string"
+                },
+                "levelOfResistance": {
+                  "type": "string"
+                },
+                "metabolic": {
+                  "type": "string"
+                },
+                "itnUsage": {
+                  "type": "string"
+                },
+                "sprayInput": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "population",
+                "seasonalityOfTransmission",
+                "currentPrevalence",
+                "bitingIndoors",
+                "bitingPeople",
+                "levelOfResistance",
+                "metabolic",
+                "itnUsage",
+                "sprayInput"
+              ]
+            },
+            "interventionSettings": {
+              "type": "object",
+              "properties": {
+                "procurePeoplePerNet": {
+                  "type": "number"
+                },
+                "procureBuffer": {
+                  "type": "number"
+                },
+                "priceDelivery": {
+                  "type": "number"
+                },
+                "priceNetPBO": {
+                  "type": "number"
+                },
+                "priceNetStandard": {
+                  "type": "number"
+                },
+                "priceIRSPerPerson": {
+                  "type": "number"
+                },
+                "netUse": {
+                  "type": "string"
+                },
+                "irsUse": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "procurePeoplePerNet",
+                "procureBuffer",
+                "priceDelivery",
+                "priceNetPBO",
+                "priceNetStandard",
+                "priceIRSPerPerson",
+                "netUse",
+                "irsUse"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "budget",
+    "zones"
+  ]
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -140,8 +140,8 @@ Returns an array of graph configuration object for the prevalence graph.
 
 Properties:
 * `layout` - a plotly layout object
-* `series` -  object containing the plotly metadata for the data series 
-* `metadata` - object containg the information about the data format and how to derive the 
+* `series` - object containing the plotly metadata for the data series
+* `metadata` - object containing the information about the data format and how to derive the
 series from the data
 
 and optionally:
@@ -276,7 +276,7 @@ Return schema: [Data.schema.json](./Data.schema.json)
 ```
 
 ## GET /table/impact/config
-Returns the list of columns to display in the impacy table, along with the column display names
+Returns the list of columns to display in the impact table, along with the column display names
 
 Schema: [TableDefinition.schema.json](./TableDefinition.schema.json)
 
@@ -305,4 +305,96 @@ e.g.
     "irsUse": "IRS use",
     "casesAverted": "Cases averted across 3 yrs since intervention"
 }
+```
+
+# Strategising
+
+## POST /strategise
+Accepts a maximum budget and a list of regions with parameters and returns a
+list of costed strategies (i.e. an optimal set of interventions/regions) for
+the maximum budget and 4 other budgets corresponding to 95%, 90%, 85% and 80%
+of the maximum.
+
+Request schema: [StrategiseOptions.schema.json](StrategiseOptions.schema.json)
+
+Return schema: [Strategise.schema.json](./Strategise.schema.json)
+
+### Example
+#### Request
+```json
+{
+  "budget": 20000,
+  "zones": [
+    {
+      "name": "Region A",
+      "baselineSettings": {
+        "population": 1000,
+        "seasonalityOfTransmission": "seasonal",
+        "currentPrevalence": "30%",
+        "bitingIndoors": "high",
+        "bitingPeople": "low",
+        "levelOfResistance": "0%",
+        "metabolic": "yes",
+        "itnUsage": "0%",
+        "sprayInput": "0%"
+      },
+      "interventionSettings": {
+        "netUse": "0.8",
+        "irsUse": "0.6",
+        "procurePeoplePerNet": 1.8,
+        "procureBuffer": 7,
+        "priceNetStandard": 1.5,
+        "priceNetPBO": 2.5,
+        "priceDelivery": 2.75,
+        "priceIRSPerPerson": 5.73,
+        "budgetAllZones": 2000000,
+        "zonal_budget": 500000.05
+      }
+    }
+  ]
+}
+```
+
+#### Response
+```json
+[
+  {
+    "costThreshold": 1,
+    "strategy": {
+      "cost": 19716.3889,
+      "casesAverted": 595,
+      "interventions": [
+        {
+          "zone": "Region A",
+          "intervention": "irs-llin"
+        }
+      ]
+    }
+  },
+  {
+    "costThreshold": 0.95,
+    "strategy": {
+      "cost": 17190,
+      "casesAverted": 570,
+      "interventions": [
+        {
+          "zone": "Region A",
+          "intervention": "irs"
+        }
+      ]
+    }
+  },
+  {
+    "costThreshold": 0.9,
+    …
+  },
+  {
+    "costThreshold": 0.85,
+    …
+  },
+  {
+    "costThreshold": 0.8,
+    …
+  }
+]
 ```

--- a/tests/testthat/helper-costs.R
+++ b/tests/testthat/helper-costs.R
@@ -1,0 +1,40 @@
+get_input <- function() {
+  list(population = 1000,
+       procurePeoplePerNet = 1.8,
+       priceNetStandard = 1.5,
+       priceNetPBO = 2.5,
+       priceDelivery = 2.75,
+       procureBuffer = 7,
+       priceIRSPerPerson = 2.5,
+       casesAverted = 10,
+       casesAvertedErrorPlus = 11,
+       casesAvertedErrorMinus = 8,
+       zonal_budget = 1000)
+}
+
+get_expected_total_costs <- function() {
+  input <- get_input()
+
+  # setting these variables up to be as similar as possible to guidance
+  # https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2083
+  population <- input$population
+  procurement_buffer <- (input$procureBuffer + 100) / 100
+  cost_per_N1 <- input$priceNetStandard
+  cost_per_N2 <- input$priceNetPBO
+  price_NET_delivery <- input$priceDelivery
+  price_IRS_delivery <- input$priceIRSPerPerson * population
+
+  costs_N0 <- 0
+  costs_N1 <- (price_NET_delivery + cost_per_N1) * (population / input$procurePeoplePerNet * procurement_buffer)
+  costs_N2 <- (price_NET_delivery + cost_per_N2) * (population / input$procurePeoplePerNet * procurement_buffer)
+  costs_S1 <- 3 * price_IRS_delivery
+  costs_N1_S1 <- costs_N1 + costs_S1
+  costs_N2_S1 <- costs_N2 + costs_S1
+
+  list(costs_N0 = costs_N0,
+       costs_N1 = costs_N1,
+       costs_N2 = costs_N2,
+       costs_S1 = costs_S1,
+       costs_N1_S1 = costs_N1_S1,
+       costs_N2_S1 = costs_N2_S1)
+}

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -281,6 +281,14 @@ test_that("cost docs", {
   expect_equal(res_api$body, res_endpoint$body)
 })
 
+test_that("cost", {
+  expected_costs <- get_expected_total_costs()
+  interventions <- c("none", "llin", "llin-pbo", "irs", "irs-llin", "irs-llin-pbo")
+  for (i in seq_along(expected_costs)) {
+    expect_equal(cost(get_input(), get_input(), interventions[i]), expected_costs[[i]])
+  }
+})
+
 test_that("strategise", {
   json <- jsonlite::toJSON(list(
     budget = 20000,

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -290,33 +290,41 @@ test_that("cost", {
 })
 
 test_that("strategise", {
+  baseline_settings <- list(
+    population = 1000,
+    seasonalityOfTransmission = "seasonal",
+    currentPrevalence = "30%",
+    bitingIndoors = "high",
+    bitingPeople = "low",
+    levelOfResistance = "0%",
+    metabolic = "yes",
+    itnUsage = "0%",
+    sprayInput = "0%"
+  )
+  intervention_settings <- list(
+    netUse = "0",
+    irsUse = "0",
+    procurePeoplePerNet = 1,
+    procureBuffer = 2,
+    priceDelivery = 3,
+    priceNetStandard = 4,
+    priceNetPBO = 5,
+    priceIRSPerPerson = 6
+  )
   json <- jsonlite::toJSON(list(
-    budget = 20000,
+    budget = 52500,
     zones = list(
-      list(
-        name = "Region A",
-        baselineSettings = list(
-          population = 1000,
-          seasonalityOfTransmission = "seasonal",
-          currentPrevalence = "30%",
-          bitingIndoors = "high",
-          bitingPeople = "low",
-          levelOfResistance = "0%",
-          metabolic = "yes",
-          itnUsage = "0%",
-          sprayInput = "0%"
-        ),
-        interventionSettings = list(
-          procurePeoplePerNet = 1.8,
-          procureBuffer = 7,
-          priceDelivery = 2.75,
-          priceNetPBO = 2.5,
-          priceNetStandard = 1.5,
-          priceIRSPerPerson = 5.73,
-          netUse = "0.8",
-          irsUse = "0.6"
-        )
-      )
+      list(name = "Region A", baselineSettings = baseline_settings,
+           interventionSettings = intervention_settings),
+      list(name = "Region B", baselineSettings = baseline_settings,
+           interventionSettings = modifyList(intervention_settings,
+                                             list(irsUse = 0.8))),
+      list(name = "Region C", baselineSettings = baseline_settings,
+           interventionSettings = modifyList(intervention_settings,
+                                             list(netUse = 0.4))),
+      list(name = "Region D", baselineSettings = baseline_settings,
+           interventionSettings = modifyList(intervention_settings,
+                                             list(irsUse = 0.8, netUse = 0.4)))
     )
   ), auto_unbox=TRUE)
 
@@ -327,34 +335,39 @@ test_that("strategise", {
     list(
       list(
         costThreshold = 1,
-        strategy = list(cost = 19716.3889, casesAverted = 595, interventions = list(
-          list(zone = "Region A", intervention = "irs-llin"))
-        )
-      ),
+        strategy = list(cost = 52320, casesAverted = 1551, interventions = list(
+          list(zone = "Region A", intervention = "none"),
+          list(zone = "Region B", intervention = "irs"),
+          list(zone = "Region C", intervention = "llin-pbo"),
+          list(zone = "Region D", intervention = "irs-llin-pbo")))),
       list(
         costThreshold = 0.95,
-        strategy = list(cost = 17190, casesAverted = 570, interventions = list(
-          list(zone = "Region A", intervention = "irs"))
-        )
-      ),
+        strategy = list(cost = 44160, casesAverted = 1547, interventions = list(
+          list(zone = "Region A", intervention = "none"),
+          list(zone = "Region B", intervention = "irs"),
+          list(zone = "Region C", intervention = "llin-pbo"),
+          list(zone = "Region D", intervention = "irs")))),
       list(
         costThreshold = 0.9,
-        strategy = list(cost = 17190, casesAverted = 570, interventions = list(
-          list(zone = "Region A", intervention = "irs"))
-        )
-      ),
+        strategy = list(cost = 44160, casesAverted = 1547, interventions = list(
+          list(zone = "Region A", intervention = "none"),
+          list(zone = "Region B", intervention = "irs"),
+          list(zone = "Region C", intervention = "llin-pbo"),
+          list(zone = "Region D", intervention = "irs")))),
       list(
         costThreshold = 0.85,
-        strategy = list(cost = 3120.8333, casesAverted = 529, interventions = list(
-          list(zone = "Region A", intervention = "llin-pbo"))
-        )
-      ),
+        strategy = list(cost = 44160, casesAverted = 1547, interventions = list(
+          list(zone = "Region A", intervention = "none"),
+          list(zone = "Region B", intervention = "irs"),
+          list(zone = "Region C", intervention = "llin-pbo"),
+          list(zone = "Region D", intervention = "irs")))),
       list(
         costThreshold = 0.8,
-        strategy = list(cost = 3120.8333, casesAverted = 529, interventions = list(
-          list(zone = "Region A", intervention = "llin-pbo"))
-        )
-      )
+        strategy = list(cost = 34320, casesAverted = 1300, interventions = list(
+          list(zone = "Region A", intervention = "none"),
+          list(zone = "Region B", intervention = "irs"),
+          list(zone = "Region C", intervention = "llin-pbo"),
+          list(zone = "Region D", intervention = "llin-pbo"))))
     ), auto_unbox=TRUE))
 
   endpoint <- endpoint_strategise(db)

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -285,7 +285,7 @@ test_that("cost", {
   expected_costs <- get_expected_total_costs()
   interventions <- c("none", "llin", "llin-pbo", "irs", "irs-llin", "irs-llin-pbo")
   for (i in seq_along(expected_costs)) {
-    expect_equal(cost(get_input(), get_input(), interventions[i]), expected_costs[[i]])
+    expect_equal(get_cost(get_input(), get_input(), interventions[i]), expected_costs[[i]])
   }
 })
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,46 +1,5 @@
 context("config")
 
-get_input <- function() {
-  list(population = 1000,
-       procurePeoplePerNet = 1.8,
-       priceNetStandard = 1.5,
-       priceNetPBO = 2.5,
-       priceDelivery = 2.75,
-       procureBuffer = 7,
-       priceIRSPerPerson = 2.5,
-       casesAverted = 10,
-       casesAvertedErrorPlus = 11,
-       casesAvertedErrorMinus = 8,
-       zonal_budget = 1000)
-}
-
-get_expected_total_costs <- function() {
-  input <- get_input()
-
-  # setting these variables up to be as similar as possible to guidance
-  # https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2083
-  population <- input$population
-  procurement_buffer <- (input$procureBuffer + 100) / 100
-  cost_per_N1 <- input$priceNetStandard
-  cost_per_N2 <- input$priceNetPBO
-  price_NET_delivery <- input$priceDelivery
-  price_IRS_delivery <- input$priceIRSPerPerson * population
-
-  costs_N0 <- 0
-  costs_N1 <- (price_NET_delivery + cost_per_N1) * (population / input$procurePeoplePerNet * procurement_buffer)
-  costs_N2 <- (price_NET_delivery + cost_per_N2) * (population / input$procurePeoplePerNet * procurement_buffer)
-  costs_S1 <- 3 * price_IRS_delivery
-  costs_N1_S1 <- costs_N1 + costs_S1
-  costs_N2_S1 <- costs_N2 + costs_S1
-
-  list(costs_N0 = costs_N0,
-       costs_N1 = costs_N1,
-       costs_N2 = costs_N2,
-       costs_S1 = costs_S1,
-       costs_N1_S1 = costs_N1_S1,
-       costs_N2_S1 = costs_N2_S1)
-}
-
 get_costs_per_cases_averted <- function(casesAvertedField = "casesAverted") {
   input <- get_input()
   total_costs <- get_expected_total_costs()

--- a/tests/testthat/test-optimise.R
+++ b/tests/testthat/test-optimise.R
@@ -1,41 +1,59 @@
 get_data <- function() {
   tibble::tribble(
-    ~zone, ~intervention,                  ~total_costs,     ~total_cases_averted,
-    1,     "No intervention",              0,                0,
-    1,     "IRS only",                     2107590,          357880.968553733,
-    1,     "Pyrethroid LLIN only",         351510.8855,      13119.7945853333,
-    1,     "Pyrethroid-PBO LLIN only",     410096.033083333, 45938.0737261667,
-    1,     "Pyrethroid LLIN with IRS",     2459100.8855,     354230.41074385,
-    1,     "Pyrethroid-PBO LLIN with IRS", 2517686.03308333, 356708.6871857,
-    2,     "No intervention",              0,                0,
-    2,     "IRS only",                     210750,           22701.5340775,
-    2,     "Pyrethroid LLIN only",         35149.5875,       8481.55158091667,
-    2,     "Pyrethroid-PBO LLIN only",     41007.8520833333, 11145.2462262917,
-    2,     "Pyrethroid LLIN with IRS",     245899.5875,      22856.8245007917,
-    2,     "Pyrethroid-PBO LLIN with IRS", 251757.852083333, 23705.0551284583
+    ~zone, ~intervention,                  ~cost,            ~cases_averted,
+    "A",   "No intervention",              0,                0,
+    "A",   "IRS only",                     2107590,          357880.968553733,
+    "A",   "Pyrethroid LLIN only",         351510.8855,      13119.7945853333,
+    "A",   "Pyrethroid-PBO LLIN only",     410096.033083333, 45938.0737261667,
+    "A",   "Pyrethroid LLIN with IRS",     2459100.8855,     354230.41074385,
+    "A",   "Pyrethroid-PBO LLIN with IRS", 2517686.03308333, 356708.6871857,
+    "B",   "No intervention",              0,                0,
+    "B",   "IRS only",                     210750,           22701.5340775,
+    "B",   "Pyrethroid LLIN only",         35149.5875,       8481.55158091667,
+    "B",   "Pyrethroid-PBO LLIN only",     41007.8520833333, 11145.2462262917,
+    "B",   "Pyrethroid LLIN with IRS",     245899.5875,      22856.8245007917,
+    "B",   "Pyrethroid-PBO LLIN with IRS", 251757.852083333, 23705.0551284583
   )
 }
 
 test_that("optimise gives the expected results", {
   data <- get_data()
-  budget <- sum(data$total_costs) / 4
+  budget <- sum(data$cost) / 4
 
   res_full_cost <- do_optimise(data, budget)
-  expect_true(sum(res_full_cost$total_costs) <= budget)
+  expect_true(sum(res_full_cost$cost) <= budget)
   expect_equal(res_full_cost, as.data.frame(slice(data, 2, 10)))
 
   res_reduced_cost <- do_optimise(data, budget * 0.8)
-  expect_true(sum(res_reduced_cost$total_costs) <= budget)
+  expect_true(sum(res_reduced_cost$cost) <= budget)
   expect_equal(res_reduced_cost, as.data.frame(slice(data, 4, 12)))
 
-  expect_lte(sum(res_reduced_cost$total_costs), sum(res_full_cost$total_costs))
-  expect_lte(sum(res_reduced_cost$total_cases_averted), sum(res_full_cost$total_cases_averted))
+  expect_lte(sum(res_reduced_cost$cost), sum(res_full_cost$cost))
+  expect_lte(sum(res_reduced_cost$cases_averted), sum(res_full_cost$cases_averted))
 })
 
 test_that("optimise gives the expected results with minimal cost", {
   data <- get_data()
-  budget <- min(data$total_costs) / 4
+  budget <- min(data$cost) / 4
 
   res <- do_optimise(data, budget)
   expect_equal(res, as.data.frame(slice(data, 1, 7)))
+})
+
+test_that("optimise gives the expected results with no interventions", {
+  data <- get_data()
+  data <- as.data.frame(slice(data, 1))
+  budget <- sum(data$cost) / 4
+
+  res <- do_optimise(data, budget)
+  expect_equal(res, as.data.frame(slice(data, 1)))
+})
+
+test_that("optimise gives the expected results with a single intervention", {
+  data <- get_data()
+  data <- as.data.frame(slice(data, 1, 2))
+  budget <- max(data$cost)
+
+  res <- do_optimise(data, budget)
+  expect_equal(res, as.data.frame(slice(data, 2)))
 })


### PR DESCRIPTION
Expose the optimiser via a new `/strategise` endpoint

Notes:
* This implements the second option from the original ticket i.e. send all parameters to the server so that we don't rely on potentially outdated `cases_averted` figures from the app
* [Relevant section of spec.md](https://github.com/mrc-ide/mintr/blob/mrc-2433/inst/schema/spec.md#strategising) is hopefully self-explanatory
* Existing self-contained logic relating to optimiser is in `optimise.R`
* New logic for API endpoint to translate JSON data to/from format used by optimiser is in `strategise.R`
* A subsequent PR will provide metadata used to present this data in the webapp (TBC)
* Can be tested manually by spinning up mintr and making a request such as the following:
    ```sh
    curl -s localhost:8888/strategise -H "Content-Type: application/json" -d '{"budget":20000,"zones":[{"name":"Region A","baselineSettings":{"population":1000,"seasonalityOfTransmission":"seasonal","currentPrevalence":"30%","bitingIndoors":"high","bitingPeople":"low","levelOfResistance":"0%","metabolic":"yes","itnUsage":"0%","sprayInput":"0%"},"interventionSettings":{"netUse":"0.8","irsUse":"0.6","procurePeoplePerNet":1.8,"procureBuffer":7,"priceNetStandard":1.5,"priceNetPBO":2.5,"priceDelivery":2.75,"priceIRSPerPerson":5.73,"budgetAllZones":2000000,"zonal_budget":500000.05}}]}' | jq
    ```
* Any tips for improving R code always appreciated!