### PR TITLE
mrc-2491 Implement metadata-driven UI changes for strategising across regions

### DIFF
--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -112,7 +112,7 @@
                   "xref": "paper",
                   "x0": 0,
                   "x1": 1,
-                  "y_formula": "{zonal_budget}",
+                  "y_formula": "{budgetAllZones}",
                   "line":{
                       "color": "red",
                       "width": 1,

--- a/inst/json/intervention_options.json
+++ b/inst/json/intervention_options.json
@@ -130,33 +130,10 @@
                             "helpText": "Include the average cost for both the IRS product and implementation of IRS. If different IRS products are used in different years, please average the product costs and provide an annual cost per person protected by IRS (in $USD)"
                         }
                     ]
-                },
-                {
-                    "controls": [
-                        {
-                            "name": "budgetAllZones",
-                            "label": "Total available budget ($USD)",
-                            "type": "number",
-                            "required": true,
-                            "value": 2000000,
-                            "helpText": "Include the average cost for both the IRS product and implementation of IRS. If different IRS products are used in different years, please average the product costs and provide an annual cost per person protected by IRS (in $USD)"
-                        }
-                    ]
-                },
-                {
-                    "controls": [
-                        {
-                            "name": "zonal_budget",
-                            "label": "Zonal budget ($USD)",
-                            "type": "number",
-                            "required": true,
-                            "value": 500000.05
-                        }
-                    ]
                 }
             ],
             "collapsible": true,
-            "documentation": "<p>The price of different vector control interventions will vary so can be defined by the user in $USD. For simplicity, it is assumed that there is a linear relationship between cost and population coverage, we do not consider inflation in this iteration of the tool.</p><strong>Price of pyrethroid LLIN ($USD)</strong><p>Price per pyrethroid-only ITN (expected to be replaced every 3-years).</p><strong>Price of Pyrethroid-PBO ITN ($USD)</strong><p>Price per Pyrethroid-PBO ITN (expected to be replaced every 3-years).</p><strong>ITN mass distribution campaign delivery cost per person ($USD)</strong><p>Cost to deliver nets to each person (equivalent for each ITN type). enough nets are provided to match the number of people per net and the procurement buffer.</p><strong>Annual cost of IRS* per person ($USD)</strong><p>The price per person of long-lasting IRS product averaged for each year. Include the average cost for both the IRS product and implementation of IRS. If different IRS products are used in different years, please average the product costs and provide an annual cost per person protected by IRS (in $USD)</p><strong>Total available budget ($USD)</strong><p>The total available budget to cover the next 3-years, is required to assess the most feasible intervention options across zones. Cost effectivessness can be optimised across zones.</p><strong>Zonal budget ($USD)</strong><p>The decision makers can choose to cap the budget for each zone to some specified maximum. Please enter the budget for this zone.</p><p>To compare the cost effectiveness of products, the costs are estimated across a 3-year period to account for the different distribution schedules of net mass campaigns and IRS deployment.</p><p><i>*IRS refers to a long-lasting non-pyrethroid IRS product (impact reflects recent Actellic 300CS and SumiShield products).</i></p>"
+            "documentation": "<p>The price of different vector control interventions will vary so can be defined by the user in $USD. For simplicity, it is assumed that there is a linear relationship between cost and population coverage, we do not consider inflation in this iteration of the tool.</p><strong>Price of pyrethroid LLIN ($USD)</strong><p>Price per pyrethroid-only ITN (expected to be replaced every 3-years).</p><strong>Price of Pyrethroid-PBO ITN ($USD)</strong><p>Price per Pyrethroid-PBO ITN (expected to be replaced every 3-years).</p><strong>ITN mass distribution campaign delivery cost per person ($USD)</strong><p>Cost to deliver nets to each person (equivalent for each ITN type). enough nets are provided to match the number of people per net and the procurement buffer.</p><strong>Annual cost of IRS* per person ($USD)</strong><p>The price per person of long-lasting IRS product averaged for each year. Include the average cost for both the IRS product and implementation of IRS. If different IRS products are used in different years, please average the product costs and provide an annual cost per person protected by IRS (in $USD)</p><p>To compare the cost effectiveness of products, the costs are estimated across a 3-year period to account for the different distribution schedules of net mass campaigns and IRS deployment.</p><p><i>*IRS refers to a long-lasting non-pyrethroid IRS product (impact reflects recent Actellic 300CS and SumiShield products).</i></p>"
         }
     ]
 }

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -346,9 +346,7 @@ Return schema: [Strategise.schema.json](./Strategise.schema.json)
         "priceNetStandard": 1.5,
         "priceNetPBO": 2.5,
         "priceDelivery": 2.75,
-        "priceIRSPerPerson": 5.73,
-        "budgetAllZones": 2000000,
-        "zonal_budget": 500000.05
+        "priceIRSPerPerson": 5.73
       }
     }
   ]

--- a/tests/testthat/helper-costs.R
+++ b/tests/testthat/helper-costs.R
@@ -9,7 +9,7 @@ get_input <- function() {
        casesAverted = 10,
        casesAvertedErrorPlus = 11,
        casesAvertedErrorMinus = 8,
-       zonal_budget = 1000)
+       budgetAllZones = 1000)
 }
 
 get_expected_total_costs <- function() {

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -53,10 +53,10 @@ test_that("cases averted vs costs graph config series formulas give correct resu
 
 test_that("cases averted vs costs graph config shape formula gives correct results", {
   json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
-  zonal_budget <- json$layout$shapes$y_formula
+  budgetAllZones <- json$layout$shapes$y_formula
   
   inputs <- get_input()
-  expect_equal(evaluate(zonal_budget), inputs$zonal_budget)
+  expect_equal(evaluate(budgetAllZones), inputs$budgetAllZones)
 })
 
 test_that("cost per case graph config contains valid intervention ids", {


### PR DESCRIPTION
mintr changes required for mrc-2492 i.e:

- Remove budgets from parameters panel and replace zonal with global budget elsewhere, including horizontal marker in cost effectiveness chart
- Note that although the global budget will now be set on the strategise page it is still applied to each region so that each region can be serialised/visualised independently
- These changes don't require a bump to `appStateKey` as each existing regions, when deserialised, will already have a global budget which is now used in the charts. This will obviously cause the markers to be drawn in a different place, but attempting to migrate the zonal budgets to global doesn't seem to add much value, considering that we don't have infrastructure in place to do such migrations but mainly because the zonal budget could all differ, and the global budget will be overridden as soon as users use the strategise feature
