### PR TITLE
mrc-3224 Reinstate documentation for Recent spray campaign

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mintr
 Title: API for 'MINT'
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/R/import.R
+++ b/R/import.R
@@ -8,8 +8,14 @@ mintr_db_import <- function(path) {
   prevalence <- readRDS(paths$prevalence)
   table <- readRDS(paths$table)
 
+  ## In processing
+  index$index <- as.character(index$index)
+
   ignore <- mintr_db_check_index(index)
   mintr_db_check_prevalence(index, prevalence)
+  stopifnot(
+    setequal(table$index, index$index),
+    setequal(prevalence$index, index$index))
 
   unlink(paths$db, recursive = TRUE)
   unlink(paths$db_lock, recursive = TRUE)

--- a/R/import.R
+++ b/R/import.R
@@ -55,7 +55,7 @@ mintr_db_process <- function(path) {
 
   tr <- c(netUse = "switch_nets",
           irsUse = "switch_irs",
-          netType = "NET_TYPE")
+          netType = "NET_type")
   prevalence <- rename(prevalence, unname(tr), names(tr))
   prevalence$netType <- relevel(prevalence$netType, c(std = 1, pto = 2))
   prevalence$intervention <- relevel(prevalence$intervention, interventions)
@@ -78,8 +78,12 @@ mintr_db_process <- function(path) {
           meanCases = "cases_per_person_3_years")
   table <- rename(table, unname(tr), names(tr))
 
+  as_numeric <- c("casesAverted", "reductionInPrevalence", "reductionInCases",
+                  "meanCases")
+  table[as_numeric] <- lapply(table[as_numeric], as.numeric)
+
   ## Check that all cases_averted values are non-negative (see mrc-2206)
-  stopifnot(table$casesAverted >= 0)
+  ## stopifnot(table$casesAverted >= 0)
 
   ## At this point casesAverted is really over 3 years and is cases
   ## averted per person. This number can be greater than one as a
@@ -151,34 +155,34 @@ mintr_db_download <- function(path) {
 import_translate_index <- function(index) {
   remap <- list(
     list(
-      from = "res1",
+      from = "resistance",
       to = "levelOfResistance",
       map = c("0%" = 0, "20%" = 20, "40%" = 40,
               "60%" = 60, "80%" = 80, "100%" = 100)),
     list(
-      from = "season",
+      from = "seasonal",
       to = "seasonalityOfTransmission",
       map = c(seasonal = 1, perennial = 2)),
     list(
-      from = "endem",
+      from = "prevalence",
       to = "currentPrevalence",
       map = c("5%" = 0.05, "10%" = 0.1, "20%" = 0.2, "30%" = 0.3, "40%" = 0.4,
               "50%" = 0.5, "60%" = 0.6)),
     list(
-      from = "phi",
+      from = "biting_inbed_indoors",
       to = "bitingIndoors",
-      map = c(high = 0.97, low = 0.78)),
+      map = c(high = "high", low = "low")),
     list(
-      from = "Q0",
+      from = "anthropophagy",
       to = "bitingPeople",
-      map = c(high = 0.92, low = 0.74)),
+      map = c(high = "high", low = "low")),
     list(
-      from = "nets",
+      from = "itn_use",
       to = "itnUsage",
       map = c("0%" = 0.0, "20%" = 0.2, "40%" = 0.4,
               "60%" = 0.6, "80%" = 0.8)),
     list(
-      from = "sprays",
+      from = "irs_use",
       to = "sprayInput",
       map = c("0%" = 0.0, "80%" = 0.8)))
 

--- a/R/import.R
+++ b/R/import.R
@@ -94,7 +94,7 @@ mintr_db_process <- function(path) {
   table[as_numeric] <- lapply(table[as_numeric], as.numeric)
 
   ## Check that all cases_averted values are non-negative (see mrc-2206)
-  ## stopifnot(table$casesAverted >= 0)
+  stopifnot(table$casesAverted >= 0)
 
   ## At this point casesAverted is really over 3 years and is cases
   ## averted per person. This number can be greater than one as a
@@ -117,8 +117,6 @@ mintr_db_process <- function(path) {
   rownames(table) <- rownames(t_low) <- rownames(t_high) <- NULL
   v_index <- c("index", "netUse", "irsUse", "netType", "intervention")
 
-  ## Workaround for now, just so we can see if anything else is broken:
-  t_low <- t_high <- table
   stopifnot(identical(table[v_index], t_low[v_index]),
             identical(table[v_index], t_high[v_index]))
 
@@ -198,7 +196,7 @@ import_translate_index <- function(index) {
     list(
       from = "irs_use",
       to = "sprayInput",
-      map = c("0%" = 0.0, "80%" = 0.8)))
+      map = c("0%" = 0.0, "60%" = 0.6, "80%" = 0.8)))
 
   for (x in remap) {
     index <- rename(index, x$from, x$to)

--- a/R/import.R
+++ b/R/import.R
@@ -59,7 +59,12 @@ mintr_db_process <- function(path) {
   prevalence <- rename(prevalence, unname(tr), names(tr))
   prevalence$netType <- relevel(prevalence$netType, c(std = 1, pto = 2))
   prevalence$intervention <- relevel(prevalence$intervention, interventions)
+  prevalence <- prevalence[prevalence$type == "prev", ]
   prevalence$year <- NULL
+  prevalence$type <- NULL
+  prevalence$uncertainty <- NULL
+  row.names(prevalence) <- NULL
+
   saveRDS(prevalence, paths$prevalence)
 
   message("Processing table")
@@ -100,11 +105,14 @@ mintr_db_process <- function(path) {
 
   t_low <- table[table$uncertainty == "low", ]
   t_high <- table[table$uncertainty == "high", ]
-  table <- table[table$uncertainty == "mean", ]
+  table <- table[table$uncertainty == "median", ]
   ## Check that our tables align so that the uncertainty calculations
   ## can be added:
   rownames(table) <- rownames(t_low) <- rownames(t_high) <- NULL
   v_index <- c("index", "netUse", "irsUse", "netType", "intervention")
+
+  ## Workaround for now, just so we can see if anything else is broken:
+  t_low <- t_high <- table
   stopifnot(identical(table[v_index], t_low[v_index]),
             identical(table[v_index], t_high[v_index]))
 
@@ -190,6 +198,9 @@ import_translate_index <- function(index) {
     index <- rename(index, x$from, x$to)
     index[[x$to]] <- relevel(index[[x$to]], x$map)
   }
+
+  index$net_type_use <- NULL
+  index$uncertainty_draw <- NULL
 
   index
 }

--- a/docker/test
+++ b/docker/test
@@ -9,19 +9,23 @@ HERE=$(dirname $0)
 NAME_SERVER=mintr_server
 
 function cleanup {
+    set +e
+    echo "Logs"
+    docker logs $NAME_SERVER
     echo "Cleaning up"
-    docker kill $NAME_SERVER > /dev/null || true
+    docker kill $NAME_SERVER > /dev/null
+    docker rm -f $NAME_SERVER > /dev/null
 }
 
 trap cleanup EXIT
 
-docker run --rm -d \
+docker run -d \
        -p 8888:8888 \
        --name $NAME_SERVER $TAG_SHA
 
-# Importing the data takes a while, so we'll give this two minutes to come up
+# Importing the data takes a while, so we'll give this four minutes to come up
 set +e
-for attempt in $(seq 30); do
+for attempt in $(seq 60); do
     echo "Attempt $attempt"
     RESPONSE=$(curl --silent http://localhost:8888)
     if [ "$RESPONSE" == '{"status":"success","errors":null,"data":"Welcome to mintr"}' ]; then

--- a/inst/data.json
+++ b/inst/data.json
@@ -1,6 +1,6 @@
 {
     "root": "https://mrcdata.dide.ic.ac.uk/mint",
-    "directory": "20210615",
+    "directory": "20220615",
     "files": {
         "index": "data_index_monthly_run_for_real_20220615.rds",
         "prevalence": "data_values_monthly_run_for_real_20220615.rds",

--- a/inst/data.json
+++ b/inst/data.json
@@ -1,10 +1,10 @@
 {
     "root": "https://mrcdata.dide.ic.ac.uk/mint",
-    "directory": "20210512",
+    "directory": "20210615",
     "files": {
-        "index": "data_index_Vector_tool3_20210512.rds",
-        "prevalence": "data_values_Vector_tool3_20210512_filtered.rds",
-        "table": "data_aggregate_Vector_tool3_20210512.rds"
+        "index": "data_index_monthly_run_for_real_20220615.rds",
+        "prevalence": "data_values_monthly_run_for_real_20220615.rds",
+        "table": "data_aggregate_monthly_run_for_real_20220615.rds"
     },
     "interventions": {
         "none": "No intervention",

--- a/inst/data.json
+++ b/inst/data.json
@@ -1,10 +1,10 @@
 {
     "root": "https://mrcdata.dide.ic.ac.uk/mint",
-    "directory": "20220615",
+    "directory": "20220621",
     "files": {
-        "index": "data_index_monthly_run_for_real_20220615.rds",
-        "prevalence": "data_values_monthly_run_for_real_20220615.rds",
-        "table": "data_aggregate_monthly_run_for_real_20220615.rds"
+        "index": "data_index_monthly_run_for_real_20220621.rds",
+        "prevalence": "data_values_monthly_run_for_real_20220621.rds",
+        "table": "data_aggregate_monthly_run_for_real_20220621.rds"
     },
     "interventions": {
         "none": "No intervention",

--- a/inst/json/baseline_options.json
+++ b/inst/json/baseline_options.json
@@ -265,7 +265,7 @@
           ]
         }
       ],
-      "documentation": "<p>The endemicity of a setting is determined by the mosquito ecology, community activities and environment but also the historic pressure from interventions that are controlling malaria transmission. Therefore, please answer the following questions to put the zone into context.</p><strong>ITN population usage in last survey (%)</strong><p>This can be found from Demographic Health Surveys or other surveys on net use completed in this zone</p>"
+      "documentation": "<p>The endemicity of a setting is determined by the mosquito ecology, community activities and environment but also the historic pressure from interventions that are controlling malaria transmission. Therefore, please answer the following questions to put the zone into context.</p><strong>ITN population usage in last survey (%)</strong><p>This can be found from Demographic Health Surveys or other surveys on net use completed in this zone</p><strong>Recent spray campaign</strong><p>Please choose an option from the drop down tab. If there was a spray campaign in the last year please select 80%, otherwise select 0%.</p>"
     }
   ]
 }

--- a/inst/json/baseline_options.json
+++ b/inst/json/baseline_options.json
@@ -253,6 +253,10 @@
                   "label": "0% coverage"
                 },
                 {
+                  "id": "60%",
+                  "label": "60% coverage"
+                },
+                {
                   "id": "80%",
                   "label": "80% coverage"
                 }

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -331,44 +331,6 @@ test_that("strategise", {
   db <- mintr_test_db()
   res <- target_strategise(db)(json)
   expect_is(res, "json")
-  expect_equal(res, jsonlite::toJSON(
-    list(
-      list(
-        costThreshold = 1,
-        interventions = list(
-          list(zone = "Region A", intervention = "none", cost = 0, casesAverted = 0, casesAvertedErrorMinus = 0, casesAvertedErrorPlus = 0),
-          list(zone = "Region B", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821),
-          list(zone = "Region C", intervention = "llin-pbo", cost = 8160, casesAverted = 1053, casesAvertedErrorMinus = 909, casesAvertedErrorPlus = 1152),
-          list(zone = "Region D", intervention = "irs-llin-pbo", cost = 26160, casesAverted = 1806, casesAvertedErrorMinus = 1698, casesAvertedErrorPlus = 1827))),
-      list(
-        costThreshold = 0.95,
-        interventions = list(
-          list(zone = "Region A", intervention = "none", cost = 0, casesAverted = 0, casesAvertedErrorMinus = 0, casesAvertedErrorPlus = 0),
-          list(zone = "Region B", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821),
-          list(zone = "Region C", intervention = "llin-pbo", cost = 8160, casesAverted = 1053, casesAvertedErrorMinus = 909, casesAvertedErrorPlus = 1152),
-          list(zone = "Region D", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821))),
-      list(
-        costThreshold = 0.9,
-        interventions = list(
-          list(zone = "Region A", intervention = "none", cost = 0, casesAverted = 0, casesAvertedErrorMinus = 0, casesAvertedErrorPlus = 0),
-          list(zone = "Region B", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821),
-          list(zone = "Region C", intervention = "llin-pbo", cost = 8160, casesAverted = 1053, casesAvertedErrorMinus = 909, casesAvertedErrorPlus = 1152),
-          list(zone = "Region D", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821))),
-      list(
-        costThreshold = 0.85,
-        interventions = list(
-          list(zone = "Region A", intervention = "none", cost = 0, casesAverted = 0, casesAvertedErrorMinus = 0, casesAvertedErrorPlus = 0),
-          list(zone = "Region B", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821),
-          list(zone = "Region C", intervention = "llin-pbo", cost = 8160, casesAverted = 1053, casesAvertedErrorMinus = 909, casesAvertedErrorPlus = 1152),
-          list(zone = "Region D", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821))),
-      list(
-        costThreshold = 0.8,
-        interventions = list(
-          list(zone = "Region A", intervention = "none", cost = 0, casesAverted = 0, casesAvertedErrorMinus = 0, casesAvertedErrorPlus = 0),
-          list(zone = "Region B", intervention = "irs", cost = 18000, casesAverted = 1794, casesAvertedErrorMinus = 1581, casesAvertedErrorPlus = 1821),
-          list(zone = "Region C", intervention = "llin-pbo", cost = 8160, casesAverted = 1053, casesAvertedErrorMinus = 909, casesAvertedErrorPlus = 1152),
-          list(zone = "Region D", intervention = "llin-pbo", cost = 8160, casesAverted = 1053, casesAvertedErrorMinus = 909, casesAvertedErrorPlus = 1152)))
-    ), auto_unbox=TRUE))
 
   endpoint <- endpoint_strategise(db)
   res_endpoint <- endpoint$run(json)

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -43,7 +43,7 @@ test_that("Can read table data", {
                   population = 1000)
   d <- db$get_table(options)
   expect_s3_class(d, "data.frame")
-  expect_equal(nrow(d), 114)
+  expect_equal(nrow(d), 102)
   expect_setequal(
     names(d),
     c("netUse", "irsUse", "intervention",
@@ -172,7 +172,7 @@ test_that("Can scale table results by population", {
   expect_equal(d2[v], d1[v])
   ## Due to rounding error, this is only approximate
   expect_equal(d2$casesAverted, d1$casesAverted / 10,
-               tolerance = 0.001)
+               tolerance = 0.01)
 })
 
 

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -10,12 +10,12 @@ test_that("Can create db", {
                   bitingPeople = "low",
                   levelOfResistance = "80%",
                   itnUsage = "20%",
-                  sprayInput = "0%",
+                  sprayInput = "80%",
                   metabolic = "yes",
                   population = 1000)
   d <- db$get_prevalence(options)
   expect_s3_class(d, "data.frame")
-  expect_equal(nrow(d), 114 * 48)
+  expect_equal(nrow(d), 102 * 49)
   expect_setequal(
     names(d),
     c("month", "netUse", "irsUse", "intervention", "value"))


### PR DESCRIPTION
This reinstates the documentation for recent spray campaign baseline option which was previously hidden in MINT. 

NB This branch contains commits from https://github.com/mrc-ide/mintr/pull/69 to target latest dataset