### PR TITLE
Avoid in memory database for mintr data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     rmpk,
     ROIoptimizer,
     ROI.plugin.glpk,
-    thor,
     tidyr
 Suggests:
     glue,

--- a/R/db.R
+++ b/R/db.R
@@ -1,7 +1,7 @@
 mintr_db_open <- function(path, docs = get_compiled_docs()) {
   paths <- mintr_db_paths(path)
-  if (!file.exists(paths$db)) {
-    stop(sprintf("mintr database does not exist at '%s'", paths$db))
+  if (!file.exists(paths$index)) {
+    stop(sprintf("mintr database does not exist at '%s'", paths$index))
   }
   mintr_db$new(paths, docs)
 }
@@ -20,9 +20,9 @@ mintr_db <- R6::R6Class(
   public = list(
     initialize = function(path, docs) {
       private$path <- path
-      private$index <- readRDS(path$read$index)
+      private$index <- readRDS(path$index)
       private$baseline <- setdiff(names(private$index), "index")
-      private$ignore <- readRDS(path$read$ignore)
+      private$ignore <- readRDS(path$ignore)
       private$docs <- docs
     },
 
@@ -43,7 +43,7 @@ mintr_db <- R6::R6Class(
 
     get_prevalence = function(options) {
       key <- self$get_index(options)
-      p <- sprintf(private$path$read$prevalence, key)
+      p <- sprintf(private$path$prevalence, key)
       ret <- readRDS(p)
       prev <- mintr_db_transform_metabolic(ret, options$metabolic)
       mintr_db_set_not_applicable_values(prev)
@@ -59,7 +59,7 @@ mintr_db <- R6::R6Class(
 
     get_table = function(options) {
       key <- self$get_index(options)
-      p <- sprintf(private$path$read$table, key)
+      p <- sprintf(private$path$table, key)
       ret <- readRDS(p)
       to_round <- c("casesAverted", "casesAvertedErrorMinus",
                     "casesAvertedErrorPlus")
@@ -75,13 +75,9 @@ mintr_db <- R6::R6Class(
 ## Some constants that crop up everywhere
 mintr_db_paths <- function(path) {
   list(index = file.path(path, "index.rds"),
-       prevalence = file.path(path, "prevalence.rds"),
-       table = file.path(path, "table.rds"),
-       read = list(
-         index = file.path(path, "index2.rds"),
-         ignore = file.path(path, "ignore.rds"),
-         table = file.path(path, "table", "%d.rds"),
-         prevalence = file.path(path, "prevalence", "%d.rds")))
+       ignore = file.path(path, "ignore.rds"),
+       table = file.path(path, "table", "%d.rds"),
+       prevalence = file.path(path, "prevalence", "%d.rds"))
 }
 
 

--- a/R/import.R
+++ b/R/import.R
@@ -19,18 +19,8 @@ mintr_db_process <- function(path) {
 
   message("Processing prevalence")
   path_prevalence_raw <- file.path(path, raw$directory, raw$files$prevalence)
-  prevalence <- readRDS(path_prevalence_raw)
-  i <- order(prevalence$index)
-  prevalence <- prevalence[i, ]
-  rownames(prevalence) <- NULL
-
-  tr <- c(netUse = "switch_nets",
-          irsUse = "switch_irs",
-          netType = "NET_TYPE")
-  prevalence <- rename(prevalence, unname(tr), names(tr))
-  prevalence$netType <- relevel(prevalence$netType, c(std = 1, pto = 2))
-  prevalence$intervention <- relevel(prevalence$intervention, interventions)
-  prevalence$year <- NULL
+  prevalence <- mintr_db_process_prevalence(readRDS(path_prevalence_raw),
+                                            interventions)
 
   mintr_db_check_prevalence(index, prevalence)
 
@@ -191,4 +181,20 @@ mintr_db_docker <- function(path) {
   ## Remove intermediate and derived files so that we get something
   ## nice and small to keep in the docker image:
   unlink(path_downloads, recursive = TRUE)
+}
+
+
+mintr_db_process_prevalence <- function(prevalence, interventions) {
+  i <- order(prevalence$index)
+  prevalence <- prevalence[i, ]
+  rownames(prevalence) <- NULL
+
+  tr <- c(netUse = "switch_nets",
+          irsUse = "switch_irs",
+          netType = "NET_TYPE")
+  prevalence <- rename(prevalence, unname(tr), names(tr))
+  prevalence$netType <- relevel(prevalence$netType, c(std = 1, pto = 2))
+  prevalence$intervention <- relevel(prevalence$intervention, interventions)
+  prevalence$year <- NULL
+  prevalence
 }

--- a/R/main.R
+++ b/R/main.R
@@ -13,11 +13,6 @@ Options:
 main <- function(args = commandArgs(TRUE)) {
   opts <- main_args(args)
   port <- opts$port
-  ## This is primarily run from the docker container, where we need to
-  ## import the data from the processed .rds files into the database,
-  ## ready for the API.
-  message("Importing data")
-  mintr_db_import(opts$data)
   message("Compiling docs")
   docs <- get_compiled_docs()
   message("Opening database")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,6 @@ RUN install2.r --error \
         plumber \
         remotes \
         testthat \
-        thor \
         tidyr \
         dplyr \
         ROI.plugin.glpk

--- a/scripts/import
+++ b/scripts/import
@@ -14,7 +14,6 @@ import <- function(root) {
   path_data <- file.path(root, "tests/testthat/data")
   mintr_db_download(path_data)
   mintr_db_process(path_data)
-  mintr_db_import(path_data)
 }
 
 if (!interactive()) {

--- a/tests/testthat/helper-mintr.R
+++ b/tests/testthat/helper-mintr.R
@@ -6,9 +6,8 @@ mintr_test_db <- function() {
 
 ## Somewhat friendly initialisation script for CI
 mintr_test_db_init <- function() {
-  if (!file.exists(mintr_db_paths("data")$db)) {
+  if (!file.exists(mintr_db_paths("data")$index)) {
     mintr_db_download("data")
     mintr_db_process("data")
-    mintr_db_import("data")
   }
 }

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -117,9 +117,12 @@ test_that("index must conform to baseline options", {
 
 
 test_that("prevelance must conform", {
-  skip("needs refactor")
   index <- readRDS("data/index.rds")
-  prevalence <- readRDS("data/prevalence.rds")
+
+  raw <- jsonlite::read_json(mintr_path("data.json"))
+  path_prevalence_raw <- file.path("data", raw$directory, raw$files$prevalence)
+  prevalence <- mintr_db_process_prevalence(readRDS(path_prevalence_raw),
+                                            raw$interventions)
 
   expect_error(
     mintr_db_check_prevalence(index, prevalence[names(prevalence) != "irsUse"]),

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -61,7 +61,7 @@ test_that("Can read table data", {
 test_that("error if db not present", {
   expect_error(
     mintr_db_open(tempfile()),
-    "mintr database does not exist at '.+mintr.db'")
+    "mintr database does not exist at '.+index.rds'")
 })
 
 
@@ -117,6 +117,7 @@ test_that("index must conform to baseline options", {
 
 
 test_that("prevelance must conform", {
+  skip("needs refactor")
   index <- readRDS("data/index.rds")
   prevalence <- readRDS("data/prevalence.rds")
 
@@ -150,7 +151,7 @@ test_that("docker build filters files", {
 
   mintr_db_docker(tmp)
 
-  expect_setequal(dir(tmp), c("index.rds", "prevalence.rds", "table.rds"))
+  expect_setequal(dir(tmp), c("index.rds", "ignore.rds", "prevalence", "table"))
 })
 
 


### PR DESCRIPTION
This PR changes from storing things in a key-value store to just piles of files on disk. TBH this is much simpler and will be nicer in practice I think as we'll have much faster startup times, as well as reducing the amount of RAM needed for API to run.

If done correctly, this should have no changes visible to mint