### PR TITLE
Install from the universe

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,25 +7,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
-RUN install2.r --error \
-        commonmark \
+COPY docker/install_packages /usr/local/bin/
+
+RUN install_packages \
+        --repo=https://mrc-ide.r-universe.dev \
+        --repo=https://r-opt.r-universe.dev \
         R6 \
+        ROI.plugin.glpk \
+        ROIoptimizer \
+        commonmark \
+        dplyr \
         glue \
         jsonlite \
         jsonvalidate \
         plumber \
+        porcelain \
         remotes \
+        rmpk \
         testthat \
         thor \
-        tidyr \
-        dplyr \
-        ROI.plugin.glpk
-
-RUN installGithub.r \
-        ropensci/jsonvalidate \
-        reside-ic/porcelain \
-        r-opt/rmpk \
-        r-opt/ROIoptimizer
+        tidyr
 
 WORKDIR /mintr
 

--- a/docker/install_packages
+++ b/docker/install_packages
@@ -1,0 +1,15 @@
+#!/usr/bin/env Rscript
+'Usage:
+install_packages [--repo=REPO...] <package>...' -> usage
+opts <- docopt::docopt(usage)
+
+repos <- opts$repo
+packages <- opts$package
+
+options(repos = c(repos, getOption("repos")))
+install.packages(packages, Ncpus = 4L)
+
+msg <- setdiff(packages, .packages(TRUE))
+if (length(msg) > 0L) {
+  stop("Failed to install: ", paste(msg, collapse = ", "))
+}


### PR DESCRIPTION
This PR uses the r universe to install development versions of packages, rather than github, which avoids rate limiting. Thankfully Dirk has put all the optimisation packages in a universe so this is fairly straightforward. The install_packages script was copied over from naomi (also used in hintr)