### PR TITLE
mrc-3996 Correct cases averted figures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.RData
 docs
 js/node_modules
 js/bundle*js
@@ -11,3 +12,7 @@ import
 tests/testthat/data
 .Rproj.user
 .Rhistory
+package.json
+package-lock.json
+node_modules
+test-results

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ After cloning the repository, ensure you have all R package dependencies with
 
 You will need a copy of the data. Run `./scripts/import` which will download, process and import the mintr database in `tests/testthat/data`, which will then be available for tests.
 
+## Browser tests
+
+Browser tests are included (in `tests/e2e`) in order to test config changes made in mintr are rendered correctly in MINT. To run browser tests locally:
+1. Install [Playwright](https://playwright.dev/docs/intro#installing-playwright)
+2. Run mintr and MINT in docker with `./docker/run_app` - this runs the mintr docker image pushed for the current git SHA, and the master branch of MINT. Change the line `export MINT_BRANCH=master` to run a different MINT branch. 
+3. Run `npx playwright test` from `tests/e2e`
+
+The browser tests are also run as part of the BuildKite pipeline, in a docker container built from `docker/test-e2e.dockerfile` using config from `tests/e2e/playwright.docker.config.ts`
+
+
 ## Deployment
 
 Deployment on the DIDE network is descrbed in the [Knowledge Base article](https://mrc-ide.myjetbrains.com/youtrack/articles/mrc-A-10/MINT---mintr#server)

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -10,8 +10,15 @@ steps:
     command: docker/test
     agents:
       queue: "browser-test"
+      
+  - label: ":hammer: Browser tests"
+    command: docker/test-e2e
+    agents:
+      queue: "browser-test"      
 
   - wait
 
   - label: ":shipit: Push images"
     command: docker/push
+  
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  mintr:
+    image: mrcide/mintr:${GIT_SHA}
+  mint:
+    depends_on:
+    - mintr
+    image: mrcide/mint:${MINT_BRANCH}
+    ports:
+    - 8080:8080
+    volumes:
+    - ./docker/mint.properties:/etc/mint/config.properties:ro

--- a/docker/clear
+++ b/docker/clear
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+docker rm --force $(docker ps -aq)
+docker network prune --force
+exit 0

--- a/docker/common
+++ b/docker/common
@@ -7,9 +7,9 @@ PACKAGE_ORG=mrcide
 # single commit) so you end up with a detached head and git rev-parse
 # doesn't work
 if [ -n "$BUILDKITE" ]; then
-    GIT_SHA=${BUILDKITE_COMMIT:0:7}
+    export GIT_SHA=${BUILDKITE_COMMIT:0:7}
 else
-    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+    export GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
 fi
 
 if [ -n "$BUILDKITE" ]; then

--- a/docker/mint.properties
+++ b/docker/mint.properties
@@ -1,0 +1,1 @@
+mintr_url=http://mintr:8888

--- a/docker/run_app
+++ b/docker/run_app
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+HERE=$(dirname $0)
+. $HERE/common
+
+export MINT_BRANCH=master
+
+docker-compose up -d

--- a/docker/test-e2e
+++ b/docker/test-e2e
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -ex
+HERE=$(dirname $0)
+
+E2E_TAG=mintr-e2e
+
+function cleardocker() {
+  $HERE/clear
+}
+
+trap cleardocker EXIT
+
+# run the mint and mintr images
+. $HERE/run_app
+
+# build the test image
+docker build --tag $E2E_TAG \
+  -f $HERE/test-e2e.dockerfile \
+  .
+  
+# make sure app is available
+curl --retry 10 --retry-all-errors http://localhost:8080   
+
+# run the test image on the network
+docker run --rm \
+    --network=mintr_default \
+    $E2E_TAG

--- a/docker/test-e2e.dockerfile
+++ b/docker/test-e2e.dockerfile
@@ -1,0 +1,12 @@
+FROM node:19
+
+ADD tests/e2e /usr/app
+
+WORKDIR /usr/app
+RUN npm install -D @playwright/test
+RUN npx playwright install
+RUN npx playwright install-deps
+
+RUN rm playwright.config.ts
+RUN mv playwright.docker.config.ts playwright.config.ts
+CMD npx playwright test

--- a/inst/json/cost_docs.md
+++ b/inst/json/cost_docs.md
@@ -18,8 +18,7 @@ and the direction of change is reflective of reality according to model checks a
 *   Interventions: The ITN and IRS combination used for the scenario.
 *   Net use (%): The percentage of people using a ITN the previous night.
 *   IRS cover (%): The percentage of people sleeping in an IRS protected home.
-*   Mean cases averted per 1,000 people per year across 3 years: The predicted number of clinical cases per 1,000 people
-averted by the intervention package, averaged across 3 years, relative to the continuation of the 'do-nothing' scenario.
+*   Total cases averted: Total number of clinical cases averted in the population over 3 years, relative to the 'no intervention' scenario
 *   Total costs (USD): The total cost in USD expected for the product procurement and implementation for the
  intervention package to cover a 3-year period of protection.
 *   Cost per case averted across 3 years: The cost in USD per case averted per 3-year campaign relative to the

--- a/inst/json/cost_docs.md
+++ b/inst/json/cost_docs.md
@@ -2,7 +2,7 @@
 
 **Graphs**
 
-The first figure shows total costs and cases averted following a 3-year intervention package introduced at year 0.
+The first figure shows costs per 1,000 people and cases averted per 1,000 people following a 3-year intervention package introduced at year 0.
 
 The absolute costs are predicted and shown for each intervention package. The summary information provided by the user is shown to indicate the ITN usage expected in
 the zone and the expected IRS coverage to be achieved in the zone.

--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -22,7 +22,7 @@
               },
               {
                   "id": "llin",
-                  "y_formula": ["({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
+                  "y_formula": ["({priceDelivery} + {priceNetStandard}) * 1000 / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
                   "name": "Pyrethroid LLIN only",
                   "type": "scatter",
                   "marker": {"color": "blue", "size": 10},
@@ -36,7 +36,7 @@
               },
               {
                   "id": "llin-pbo",
-                  "y_formula": ["({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
+                  "y_formula": ["({priceDelivery} + {priceNetPBO}) * 1000 / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
                   "name": "Pyrethroid-PBO ITN only",
                   "type": "scatter",
                   "marker": {"color": "turquoise", "size": 10},
@@ -50,7 +50,7 @@
               },
               {
                   "id": "pyrrole-pbo",
-                  "y_formula": ["({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
+                  "y_formula": ["({priceDelivery} + {priceNetPyrrole}) * 1000 / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100"],
                   "name": "Pyrethroid-pyrrole ITN only",
                   "type": "scatter",
                   "marker": {"color": "darkgreen", "size": 10},
@@ -64,7 +64,7 @@
               },
               {
                   "id": "irs",
-                  "y_formula": ["3 * {priceIRSPerPerson} * {population}"],
+                  "y_formula": ["3 * {priceIRSPerPerson} * 1000"],
                   "name": "IRS* only",
                   "type": "scatter",
                   "marker": {"color": "purple", "size": 10},
@@ -78,7 +78,7 @@
               },
               {
                   "id": "irs-llin",
-                  "y_formula": ["({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}"],
+                  "y_formula": ["({priceDelivery} + {priceNetStandard}) * 1000 / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * 1000"],
                   "name": "Pyrethroid LLIN with IRS*",
                   "type": "scatter",
                   "marker": {"color": "darkred", "size": 10},
@@ -92,7 +92,7 @@
               },
               {
                   "id": "irs-llin-pbo",
-                  "y_formula": ["({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}"],
+                  "y_formula": ["({priceDelivery} + {priceNetPBO}) * 1000 / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * 1000"],
                   "name": "Pyrethroid-PBO ITN with IRS*",
                   "type": "scatter",
                   "marker": {"color": "orange", "size": 10},
@@ -106,7 +106,7 @@
               },
               {
                   "id": "irs-pyrrole-pbo",
-                  "y_formula": ["({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}"],
+                  "y_formula": ["({priceDelivery} + {priceNetPyrrole}) * 1000 / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * 1000"],
                   "name": "Pyrethroid-pyrrole ITN with IRS*",
                   "type": "scatter",
                   "marker": {"color": "limegreen", "size": 10},
@@ -128,7 +128,7 @@
                   "zeroline": false
               },
               "yaxis": {
-                  "title": "Total costs (USD)",
+                  "title": "Costs per 1,000 people across 3-years (USD)",
                   "showline": true,
                   "autorange": true,
                   "zeroline": false,

--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -1,6 +1,6 @@
 {
          "metadata": {
-              "x_col": "casesAvertedPer1000",
+              "x_formula": ["{casesAvertedPer1000} * 3"],
               "id_col": "intervention",
               "format": "long",
               "settings": ["irsUse", "netUse"]

--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -16,8 +16,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -30,8 +30,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -44,8 +44,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -58,8 +58,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -72,8 +72,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -86,8 +86,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -100,8 +100,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               },
               {
@@ -114,8 +114,8 @@
                   "error_x": {
                       "type": "data",
                       "width": 0,
-                      "col": "casesAvertedPer1000ErrorPlus",
-                      "colminus": "casesAvertedPer1000ErrorMinus"
+                      "cols": ["{casesAvertedPer1000ErrorPlus} * 3"],
+                      "colsminus": ["{casesAvertedPer1000ErrorMinus} * 3"]
                   }
               }
           ],

--- a/inst/json/graph_cost_per_case_config.json
+++ b/inst/json/graph_cost_per_case_config.json
@@ -8,7 +8,7 @@
         {
             "x": ["llin"],
             "id": "llin",
-            "y_formula": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)"],
             "type": "bar",
             "name": "Pyrethroid LLIN only",
             "marker": {
@@ -18,8 +18,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}"],
+                "cols": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -29,7 +29,7 @@
         {
             "x": ["llin-pbo"],
             "id": "llin-pbo",
-            "y_formula": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)"],
             "type": "bar",
             "name": "Pyrethroid-PBO ITN only",
             "marker": {
@@ -39,8 +39,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}"],
+                "cols": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -50,7 +50,7 @@
         {
             "x": ["pyrrole-pbo"],
             "id": "pyrrole-pbo",
-            "y_formula": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)"],
             "type": "bar",
             "name": "Pyrethroid-pyrrole ITN only",
             "marker": {
@@ -60,8 +60,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}"],
+                "cols": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -71,7 +71,7 @@
         {
             "x": ["irs"],
             "id": "irs",
-            "y_formula": ["(3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
+            "y_formula": ["(3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)"],
             "name": "IRS* only",
             "type": "bar",
             "marker": {
@@ -81,8 +81,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}"],
+                "cols": ["(3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -92,7 +92,7 @@
         {
             "x": ["irs-llin"],
             "id": "irs-llin",
-            "y_formula": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)"],
             "name": "Pyrethroid LLIN with IRS*",
             "type": "bar",
             "marker": {
@@ -102,8 +102,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}"],
+                "cols": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -113,7 +113,7 @@
         {
             "x": ["irs-llin-pbo"],
             "id": "irs-llin-pbo",
-            "y_formula": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)"],
             "name": "Pyrethroid-PBO ITN with IRS*",
             "type": "bar",
             "marker": {
@@ -123,8 +123,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}"],
+                "cols": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,
@@ -134,7 +134,7 @@
          {
             "x": ["irs-pyrrole-pbo"],
             "id": "irs-pyrrole-pbo",
-            "y_formula": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"],
+            "y_formula": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)"],
             "name": "Pyrethroid-pyrrole ITN with IRS*",
             "type": "bar",
             "marker": {
@@ -144,8 +144,8 @@
             "hovertemplate": "$%{y:.1f}0 +$%{error_y.array:.1f}0 / -$%{error_y.arrayminus:.1f}0",
             "error_y": {
                 "type": "data",
-                "cols": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"],
-                "colsminus": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}"],
+                "cols": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)"],
+                "colsminus": ["(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)"],
                 "visible": true,
                 "thickness": 1.5,
                 "width": 0,

--- a/inst/json/impact_docs.md
+++ b/inst/json/impact_docs.md
@@ -35,7 +35,6 @@ may perform well when different assumptions are made.
 *   Prevalence under 5 years: Year 2 post intervention: The prevalence in children of 6-months to 5 years of age two years after the intervention package is implemented.
 *   Prevalence under 5 years: Year 3 post intervention: The prevalence in children of 6-months to 5 years of age three years after the intervention package is implemented.
 *   Relative reduction in prevalence at 36 months post intervention: The relative efficacy of the investigated intervention package against the 'do-nothing' scenario at 3-years post switching to the alternative interventions.
-*   Mean cases averted annually per population across 3 years since intervention: The absolute number of clinical cases averted given the population size inputted and relative to the 'do-nothing' scenario.
 *   Mean cases averted per 1,000 people annually across 3 years since intervention: The mean number of clinical cases averted annually per 1,000 people per year given the population size inputted and relative to the 'do-nothing' scenario.
 *   Relative reduction in clinical cases across 3 years since intervention (%): The percentage-efficacy of the investigated intervention package against clinical cases relative to the 'do-nothing' scenario.
 *   Mean cases per person per year averaged across 3 years: The predicted number of clinical cases per person, averaged across 3 years since intervention.

--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -24,17 +24,17 @@
     "format": "0%"
   },
   {
-    "valueCol": "casesAvertedPer1000",
-    "displayName": "Mean cases averted per 1,000 people per year across 3 years",
+    "valueCol": "casesAverted",
+    "displayName": "Total cases averted",
     "error": {
       "minus": {
-        "valueCol": "casesAvertedPer1000ErrorMinus"
+        "valueCol": "casesAvertedErrorMinus"
       },
       "plus": {
-        "valueCol": "casesAvertedPer1000ErrorPlus"
+        "valueCol": "casesAvertedErrorPlus"
       }
     },
-    "transform": "round({} / 10) * 10"
+    "transform": "round({} * 3 / 10) * 10"
   },
   {
     "valueCol": "intervention",

--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -57,37 +57,37 @@
     "displayName": "Cost per case averted across 3 years",
     "valueTransform": {
       "none": "'reference'",
-      "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}",
-      "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}",
-      "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted}",
-      "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
-      "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
-      "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}",
-      "irs-pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAverted}"
+      "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)",
+      "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)",
+      "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted} * 3)",
+      "irs": "(3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)",
+      "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)",
+      "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)",
+      "irs-pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)"
     },
     "error": {
       "minus": {
         "valueTransform": {
           "none": "'reference'",
-          "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}",
-          "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}",
-          "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorPlus}",
-          "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}",
-          "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}",
-          "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}",
-          "irs-pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorPlus}"
+          "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorPlus} * 3)",
+          "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorPlus} * 3)",
+          "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorPlus} * 3)",
+          "irs": "(3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)",
+          "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)",
+          "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)",
+          "irs-pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorPlus} * 3)"
         }
       },
       "plus": {
         "valueTransform": {
           "none": "'reference'",
-          "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}",
-          "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}",
-          "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAvertedErrorMinus}",
-          "irs": "(3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}",
-          "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}",
-          "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}",
-          "irs-pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / {casesAvertedErrorMinus}"
+          "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorMinus} * 3)",
+          "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorMinus} * 3)",
+          "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAvertedErrorMinus} * 3)",
+          "irs": "(3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)",
+          "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)",
+          "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)",
+          "irs-pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAvertedErrorMinus} * 3)"
         }
       }
     },

--- a/inst/json/table_cost_config.json
+++ b/inst/json/table_cost_config.json
@@ -59,7 +59,7 @@
       "none": "'reference'",
       "llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)",
       "llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)",
-      "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / {casesAverted} * 3)",
+      "pyrrole-pbo": "(({priceDelivery} + {priceNetPyrrole}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100) / ({casesAverted} * 3)",
       "irs": "(3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)",
       "irs-llin": "(({priceDelivery} + {priceNetStandard}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)",
       "irs-llin-pbo": "(({priceDelivery} + {priceNetPBO}) * {population} / {procurePeoplePerNet} * ({procureBuffer} + 100) / 100 + 3 * {priceIRSPerPerson} * {population}) / ({casesAverted} * 3)",

--- a/inst/json/table_impact_config.json
+++ b/inst/json/table_impact_config.json
@@ -76,19 +76,6 @@
     "format": "0.0"
   },
   {
-    "valueCol": "casesAverted",
-    "displayName": "Mean cases averted annually per population across 3 years since intervention",
-    "error": {
-      "minus": {
-        "valueCol": "casesAvertedErrorMinus"
-      },
-      "plus": {
-        "valueCol": "casesAvertedErrorPlus"
-      }
-    },
-    "transform": "round({} / 10) * 10"
-  },
-  {
     "valueCol": "casesAvertedPer1000",
     "displayName": "Mean cases averted per 1,000 people annually across 3 years since intervention",
     "error": {

--- a/inst/schema/Graph.schema.json
+++ b/inst/schema/Graph.schema.json
@@ -6,13 +6,14 @@
       "type": "object",
       "properties": {
         "x_col": { "type": "string" },
+        "x_formula": { "type": "array", "items": { "type": "string"}},
         "y_col": { "type": "string" },
         "id_col": {"type": "string" },
         "format": { "enum": ["long"] },
         "settings": { "type": "array", "items": { "type": "string"}}
       },
       "additionalProperties": false,
-      "required": ["x_col","id_col","format"]
+      "required": ["id_col","format"]
     },
     "wideFormatMetadata": {
       "type": "object",

--- a/tests/e2e/cost-table.etest.ts
+++ b/tests/e2e/cost-table.etest.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import {
+    acceptBaseline,
+    newProject,
+    selectCoverageValues,
+    testCommonTableValues,
+    getTableRows,
+    getTextFromRowCell, costStringToNumber, approximatelyEqual
+} from "./helpers";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await newProject(page);
+    await acceptBaseline(page);
+    await selectCoverageValues(page);
+    await page.locator(".nav-item a").getByText("Table").click();
+    await page.locator(".nav-item a").getByText("Cost effectiveness").click();
+});
+
+test('cost table has expected columns', async ({ page }) => {
+    const headers = await page.locator("th div");
+    await expect(headers).toHaveCount(6);
+    await expect(await headers.allInnerTexts()).toStrictEqual([
+        "Interventions",
+        "Net use (%)",
+        "IRS* cover (%)",
+        "Total cases averted",
+        "Total costs",
+        "Cost per case averted across 3 years"
+    ]);
+});
+
+test("cost table has expected common table values", async ({page}) => {
+    await testCommonTableValues(page);
+});
+
+test("cost table has expected no intervention values", async ({page}) => {
+    const firstRow = (await getTableRows(page)).nth(0);
+    await expect(await getTextFromRowCell(firstRow, 3)).toBe("0"); // Total cases averted
+    await expect(await getTextFromRowCell(firstRow, 4)).toBe("$0"); // Total costs
+    await expect(await getTextFromRowCell(firstRow, 5)).toBe("reference"); // Cost per case averted
+});
+
+test("cost per case averted values match total cost and cases averted values", async ({page}) => {
+    const expectCostPerCaseAvertedValue = async (row) => {
+        const totalCasesAverted = Number.parseInt(await getTextFromRowCell(row, 3));
+        const totalCosts = costStringToNumber(await getTextFromRowCell(row, 4));
+        const costPerCaseAverted = costStringToNumber(await getTextFromRowCell(row, 5));
+        // Values are approximately equal because of rounding
+        expect(approximatelyEqual(costPerCaseAverted, totalCosts / totalCasesAverted)).toBe(true);
+    };
+    const rows = await getTableRows(page);
+    for (let idx = 1; idx < 8; idx++) {
+        await expectCostPerCaseAvertedValue(await rows.nth(idx));
+    }
+});

--- a/tests/e2e/helper-tests.etest.ts
+++ b/tests/e2e/helper-tests.etest.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { approximatelyEqual, costStringToNumber } from "./helpers";
+
+test("approximatelyEqual returns true for values within tolerance", () => {
+    expect(approximatelyEqual(1, 1.5)).toBe(true);
+    expect(approximatelyEqual(2.4, 1.4)).toBe(true);
+    expect(approximatelyEqual(11, 1.5, 10)).toBe(true);
+});
+
+test("approximatelyEqual return false for values outside tolerance", () => {
+    expect(approximatelyEqual(1, 2.01)).toBe(false);
+    expect(approximatelyEqual(2.3, 1.2)).toBe(false);
+    expect(approximatelyEqual(12, 1.5, 10)).toBe(false);
+});
+
+test("costStringToNumber returns correct value", () => {
+    expect(costStringToNumber("$10.99")).toBe(10.99);
+    expect(costStringToNumber("$25.17k")).toBe(25170);
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,86 @@
+import { expect } from "@playwright/test";
+export const newProject = async (page) => {
+    await page.locator("#name").fill("test project");
+    await page.locator(":nth-match(input,2)").fill("test-region");
+    await page.locator("button.btn-primary").click();
+}
+
+export const acceptBaseline = async (page) => {
+    const next = await page.getByText("Next");
+    await next.click();
+};
+
+export const selectCoverageValues = async (page, itn = "0.2", irs = "0.6") => {
+    await page.locator("select[name='netUse']").selectOption(itn);
+    await page.locator("select[name='irsUse']").selectOption(irs);
+};
+
+export const getTableRows = async (page) => {
+    return await page.locator("tbody tr");
+};
+
+export const getTextFromRowCell = async (row, index) => {
+    return await row.locator(`:nth-match(td, ${index + 1})`).innerText();
+};
+
+export const expectColumnValues = async (rows, columnIndex, expectedValues) => {
+    await expect(rows).toHaveCount(expectedValues.length);
+    for(let idx = 0; idx < expectedValues.length; idx++) {
+        await expect(await getTextFromRowCell(rows.nth(idx), columnIndex)).toBe(expectedValues[idx]);
+    }
+};
+
+export const testCommonTableValues = async (page) => {
+    const rows = await getTableRows(page);
+    // The impact and cost tables share their first three columns:
+    // Intervention
+    await expectColumnValues(rows, 0, [
+        "No intervention",
+        "Pyrethroid LLIN only",
+        "IRS* only",
+        "Pyrethroid LLIN with IRS*",
+        "Pyrethroid-PBO ITN only",
+        "Pyrethroid-PBO ITN with IRS*",
+        "Pyrethroid-pyrrole ITN only",
+        "Pyrethroid-pyrrole ITN with IRS*"
+    ]);
+
+    // Net Use
+    await expectColumnValues(rows, 1, [
+        "n/a",
+        "20%",
+        "n/a",
+        "20%",
+        "20%",
+        "20%",
+        "20%",
+        "20%"
+    ]);
+
+    // IRS use
+    await expectColumnValues(rows, 2, [
+        "n/a",
+        "n/a",
+        "60%",
+        "60%",
+        "n/a",
+        "60%",
+        "n/a",
+        "60%"
+    ]);
+};
+
+export const costStringToNumber = (costString) => {
+    const regex =  /\$([0-9.]*)(k?)/;
+    const match = costString.match(regex);
+    if (!match) {
+        return null;
+    }
+    const numericPart = Number.parseFloat(match[1]);
+    const kPart = match[2] ? 1000 : 1;
+    return numericPart * kPart;
+};
+
+export const approximatelyEqual = (val1, val2, tolerance = 1) => {
+    return Math.abs(val1 - val2) <= tolerance;
+}

--- a/tests/e2e/impact-table.etest.ts
+++ b/tests/e2e/impact-table.etest.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import {
+    newProject,
+    acceptBaseline,
+    selectCoverageValues,
+    testCommonTableValues,
+    getTableRows,
+    getTextFromRowCell, approximatelyEqual
+} from "./helpers";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await newProject(page);
+    await acceptBaseline(page);
+    await selectCoverageValues(page);
+    await page.locator(".nav-item a").getByText("Table").click();
+});
+
+test('impact table has expected columns', async ({ page }) => {
+    const headers = await page.locator("th div");
+    await expect(headers).toHaveCount(10);
+    await expect(await headers.allInnerTexts()).toStrictEqual([
+      "Interventions",
+      "Net use (%)",
+      "IRS* cover (%)",
+      "Prevalence under 5 years: Year 1 post intervention",
+      "Prevalence under 5 years: Year 2 post intervention",
+      "Prevalence under 5 years: Year 3 post intervention",
+      "Relative reduction in prevalence at 36 months post intervention",
+      "Mean cases averted per 1,000 people annually across 3 years since intervention",
+      "Relative reduction in clinical cases across 3 years since intervention (%)",
+      "Mean cases per person per year averaged across 3 years"
+    ]);
+});
+
+
+test("impact table has expected common table values", async ({page}) => {
+    await testCommonTableValues(page);
+});
+
+test("impact table has expected no intervention values", async ({page}) => {
+    const firstRow = (await getTableRows(page)).nth(0);
+    await expect(await getTextFromRowCell(firstRow, 6)).toBe("0.0"); // Relative reduction in prevalence
+    await expect(await getTextFromRowCell(firstRow, 7)).toBe("0"); // Mean cases averted per 1,000
+    await expect(await getTextFromRowCell(firstRow, 8)).toBe("0.0"); // Relative reduction in cases
+});
+
+test("cases averted annually values match total cases averted from costs table", async ({page}) => {
+    const rows = await getTableRows(page);
+    const casesAvertedAnnually = [];
+    for (let idx = 1; idx < 8; idx++) {
+        const value = Number.parseInt(await getTextFromRowCell(rows.nth(idx), 7));
+        casesAvertedAnnually.push(value);
+    }
+
+    await page.locator(".nav-item a").getByText("Cost effectiveness").click();
+    const costRows = await getTableRows(page);
+    for (let idx = 1; idx < 8; idx++) {
+        const totalCasesAverted = Number.parseInt(await getTextFromRowCell(costRows.nth(idx), 3));
+        const annualValue = Number.parseInt(casesAvertedAnnually[idx-1]);
+        // Values are approximately equal because of rounding
+        expect(approximatelyEqual(totalCasesAverted, annualValue * 3, 10)).toBe(true);
+    }
+});

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,13 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+    testMatch: "*.etest.ts",
+    fullyParallel: true,
+    use: {
+        baseURL: "http://localhost:8080",
+        screenshot: "only-on-failure",
+        actionTimeout: 0
+    }
+};
+
+export default config;

--- a/tests/e2e/playwright.docker.config.ts
+++ b/tests/e2e/playwright.docker.config.ts
@@ -1,0 +1,14 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+    testMatch: "*.etest.ts",
+    use: {
+        baseURL: "http://mint:8080",
+        screenshot: "only-on-failure"
+    },
+    workers: 1,
+    retries: 1,
+    timeout: 120000
+};
+
+export default config;

--- a/tests/testthat/helper-costs.R
+++ b/tests/testthat/helper-costs.R
@@ -1,5 +1,5 @@
 get_input <- function() {
-  list(population = 1000,
+  list(population = 10000,
        procurePeoplePerNet = 1.8,
        priceNetStandard = 1.5,
        priceNetPBO = 2.5,
@@ -13,28 +13,25 @@ get_input <- function() {
        budgetAllZones = 1000)
 }
 
-get_expected_total_costs <- function() {
+get_costs <- function(numberOfPeople) {
   input <- get_input()
-
-  # setting these variables up to be as similar as possible to guidance
-  # https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2083
-  population <- input$population
+  
   procurement_buffer <- (input$procureBuffer + 100) / 100
   cost_per_N1 <- input$priceNetStandard
   cost_per_N2 <- input$priceNetPBO
   cost_per_N3 <- input$priceNetPyrrole
   price_NET_delivery <- input$priceDelivery
-  price_IRS_delivery <- input$priceIRSPerPerson * population
-
+  price_IRS_delivery <- input$priceIRSPerPerson * numberOfPeople
+  
   costs_N0 <- 0
-  costs_N1 <- (price_NET_delivery + cost_per_N1) * (population / input$procurePeoplePerNet * procurement_buffer)
-  costs_N2 <- (price_NET_delivery + cost_per_N2) * (population / input$procurePeoplePerNet * procurement_buffer)
-  costs_N3 <- (price_NET_delivery + cost_per_N3) * (population / input$procurePeoplePerNet * procurement_buffer)
+  costs_N1 <- (price_NET_delivery + cost_per_N1) * (numberOfPeople / input$procurePeoplePerNet * procurement_buffer)
+  costs_N2 <- (price_NET_delivery + cost_per_N2) * (numberOfPeople / input$procurePeoplePerNet * procurement_buffer)
+  costs_N3 <- (price_NET_delivery + cost_per_N3) * (numberOfPeople / input$procurePeoplePerNet * procurement_buffer)
   costs_S1 <- 3 * price_IRS_delivery
   costs_N1_S1 <- costs_N1 + costs_S1
   costs_N2_S1 <- costs_N2 + costs_S1
   costs_N3_S1 <- costs_N3 + costs_S1
-
+  
   list(costs_N0 = costs_N0,
        costs_N1 = costs_N1,
        costs_N2 = costs_N2,
@@ -43,4 +40,13 @@ get_expected_total_costs <- function() {
        costs_N1_S1 = costs_N1_S1,
        costs_N2_S1 = costs_N2_S1,
        costs_N3_S1 = costs_N3_S1)
+}
+
+get_expected_total_costs <- function() {
+  input <- get_input()
+  get_costs(input$population)
+}
+
+get_expected_costs_per_1000 <- function() {
+  get_costs(1000)
 }

--- a/tests/testthat/helper-costs.R
+++ b/tests/testthat/helper-costs.R
@@ -7,9 +7,12 @@ get_input <- function() {
        priceDelivery = 2.75,
        procureBuffer = 7,
        priceIRSPerPerson = 2.5,
-       casesAverted = 10,
-       casesAvertedErrorPlus = 11,
-       casesAvertedErrorMinus = 8,
+       casesAverted = 100,
+       casesAvertedErrorPlus = 110,
+       casesAvertedErrorMinus = 80,
+       casesAvertedPer1000 = 10,
+       casesAvertedPer1000ErrorPlus = 11,
+       casesAvertedPer1000ErrorMinus = 8,
        budgetAllZones = 1000)
 }
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -59,12 +59,29 @@ test_that("cases averted vs costs graph config series formulas give correct resu
   expect_equal(evaluate(pyrrole_IRS), costs$costs_N3_S1)
 })
 
+test_that("cases averted vs costs graph config series x error formulas give correct results", {
+  json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
+  plus_formulas <- json$series$error_x$cols
+  minus_formulas <- json$series$error_x$cols_minus
+  input <- get_input()
+  
+  lapply(plus_formulas, function(x) expect_equal(evaluate(x), input$casesAvertedPer1000ErrorPlus * 3))
+  lapply(minus_formulas, function(x) expect_equal(evaluate(x), input$casesAvertedPer1000ErrorMinus * 3))
+})
+
 test_that("cases averted vs costs graph config shape formula gives correct results", {
   json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
   budgetAllZones <- json$layout$shapes$y_formula
   
   inputs <- get_input()
   expect_equal(evaluate(budgetAllZones), inputs$budgetAllZones)
+})
+
+test_that("cases averted vs costs graph config x_formula gives correct results", {
+  json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
+  inputs <- get_input()
+  x_formula <- json$metadata$x_formula
+  expect_equal(evaluate(x_formula), inputs$casesAvertedPer1000 * 3)
 })
 
 test_that("cost per case graph config contains valid intervention ids", {

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -3,7 +3,7 @@ context("config")
 get_costs_per_cases_averted <- function(casesAvertedField = "casesAverted") {
   input <- get_input()
   total_costs <- get_expected_total_costs()
-  lapply(total_costs, function(x) x/input[[casesAvertedField]])
+  lapply(total_costs, function(x) x/(input[[casesAvertedField]] * 3))
 }
 
 evaluate <- function(formula) {
@@ -190,14 +190,6 @@ test_that("impact table config contains valid intervention ids", {
   expect_equal(PBO_IRS, mint_intervention(1, 1, "pto"))
   pyrrole_IRS <- ids[[8]]
   expect_equal(pyrrole_IRS, mint_intervention(1, 1, "ig2"))
-})
-
-test_that("impact table config formulas give correct results for cases averted", {
-  json <- jsonlite::fromJSON(mintr_path("json/table_impact_config.json"))
-  input <- get_input()
-  expect_equal(input$casesAverted, input[[json$valueCol[8]]])
-  expect_equal(input$casesAvertedErrorPlus, input[[json$error$plus$valueCol[8]]])
-  expect_equal(input$casesAvertedErrorMinus, input[[json$error$minus$valueCol[8]]])
 })
 
 test_that("cost table config contains valid intervention ids", {

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -39,7 +39,7 @@ test_that("cost per case graph config formulas give correct results", {
 test_that("cases averted vs costs graph config series formulas give correct results", {
   json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
   formulas <- json$series$y_formula
-  costs <- get_expected_total_costs()
+  costs <- get_expected_costs_per_1000()
 
   none <- formulas[[1]]
   expect_equal(evaluate(none), costs$costs_N0)


### PR DESCRIPTION
This branch is deployed to mint-dev, along with the MINT branch https://github.com/mrc-ide/mint/pull/120 which includes front end support for the config changes. NB this branch should be merged alongisde that MINT branch. 

Tom has already checked the app over and confirmed the changes are as required.  

Config changes: 

Impact table:
* Removes _"Mean cases averted annually per population across 3 years since intervention"_ - expect user to look at Cost effectiveness table for per population cases averted figure

Cost-effectiveness table:
* Replaces _"Mean cases averted per 1,000 people per year across 3 years since intervention"_ with _ "Total cases averted"_, calculated by multiplying `casesAverted` figure by 3 (`casesAverted` and related error columns are per year). 
* Correct calculation of _"Cost per case averted across 3 years"_ by multiplying `casesAverted` and related error columns by 3

Cost-effectiveness graphs:
* _"Strategy costs over 3 years vs Cases averted"_: Multiply `casesAvertedPer1000` by 3 for "over 3 years" figure. Costs shown are per 1000, not total costs
* _"Strategy costs per case averted"_: Multiply `casesAverted` by 3 to get correct cost per case averted value
