### PR TITLE
mrc-3235 Include pyrrole interventions in Strategise

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,11 +40,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - name: Install system dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install v8
-
       - name: Query dependencies
         run: |
           install.packages('remotes')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,53 +1,52 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
-      - mrc-3461
+    branches: [main, master]
 
 name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
-
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Install system dependencies
-        run: |
-          brew install v8
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::covr
+            github::reside-ic/porcelain
+          needs: coverage
 
       - name: Test coverage
-        run: covr::codecov()
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+          )
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, mrc-3461]
 
 name: test-coverage
 

--- a/R/import.R
+++ b/R/import.R
@@ -1,6 +1,6 @@
 mintr_db_download <- function(path, quiet = FALSE) {
   version <- mintr_data_version()
-  root <- "https://mrcdata.dide.ic.ac.uk/mint"
+  root <- "https://github.com/mrc-ide/mintr/releases/download/data-20230208"
   url <- sprintf("%s/%s.tar", root, version)
   dir.create(path, FALSE, TRUE)
   path_tar <- file.path(path, basename(url))

--- a/R/import.R
+++ b/R/import.R
@@ -1,7 +1,7 @@
 mintr_db_download <- function(path, quiet = FALSE) {
   version <- mintr_data_version()
-  root <- "https://github.com/mrc-ide/mintr/releases/download/data-20230208"
-  url <- sprintf("%s/%s.tar", root, version)
+  root <- "https://github.com/mrc-ide/mintr/releases/download/"
+  url <- sprintf("%s/data-%s/%s.tar", root, version, version)
   dir.create(path, FALSE, TRUE)
   path_tar <- file.path(path, basename(url))
   if (!file.exists(path_tar)) {

--- a/R/strategise.R
+++ b/R/strategise.R
@@ -25,7 +25,7 @@ get_intervention_data <- function(baseline_settings, intervention_settings, db) 
   rows <- table$intervention == "none"
   if (intervention_settings$netUse != "0") {
     rows <- rows | (
-      table$intervention %in% c("llin", "llin-pbo") &
+      table$intervention %in% c("llin", "llin-pbo", "pyrrole-pbo") &
       table$netUse == intervention_settings$netUse &
       table$irsUse == "n/a"
     )
@@ -40,7 +40,7 @@ get_intervention_data <- function(baseline_settings, intervention_settings, db) 
   if (intervention_settings$netUse != "0"
     && intervention_settings$irsUse != "0") {
     rows <- rows | (
-      table$intervention %in% c("irs-llin", "irs-llin-pbo") &
+      table$intervention %in% c("irs-llin", "irs-llin-pbo", "irs-pyrrole-pbo") &
       table$netUse == intervention_settings$netUse &
       table$irsUse == intervention_settings$irsUse
     )

--- a/inst/schema/StrategiseOptions.schema.json
+++ b/inst/schema/StrategiseOptions.schema.json
@@ -74,6 +74,9 @@
                 "priceNetPBO": {
                   "type": "number"
                 },
+                "priceNetPyrrole":{
+                  "type": "number"
+                },
                 "priceNetStandard": {
                   "type": "number"
                 },
@@ -92,6 +95,7 @@
                 "procureBuffer",
                 "priceDelivery",
                 "priceNetPBO",
+                "priceNetPyrrole",
                 "priceNetStandard",
                 "priceIRSPerPerson",
                 "netUse",

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -309,6 +309,7 @@ test_that("strategise", {
     priceDelivery = 3,
     priceNetStandard = 4,
     priceNetPBO = 5,
+    priceNetPyrrole = 6,
     priceIRSPerPerson = 6
   )
   json <- jsonlite::toJSON(list(


### PR DESCRIPTION
Ensure that pyrrole interventions are included in strategise when `netUse` value is not 0. 

Also removes mac build from the github action. 