### PR TITLE
mrc-4005 Remove budget line

### DIFF
--- a/inst/json/graph_cost_cases_averted_config.json
+++ b/inst/json/graph_cost_cases_averted_config.json
@@ -134,19 +134,6 @@
                   "zeroline": false,
                   "rangemode": "series"
               },
-              "shapes": [
-              {
-                  "type": "line",
-                  "xref": "paper",
-                  "x0": 0,
-                  "x1": 1,
-                  "y_formula": "{budgetAllZones}",
-                  "line":{
-                      "color": "red",
-                      "width": 1,
-                      "dash": "dash"
-                  }
-              }],
               "hoverlabel": {
                   "namelength": -1
               },

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -69,14 +69,6 @@ test_that("cases averted vs costs graph config series x error formulas give corr
   lapply(minus_formulas, function(x) expect_equal(evaluate(x), input$casesAvertedPer1000ErrorMinus * 3))
 })
 
-test_that("cases averted vs costs graph config shape formula gives correct results", {
-  json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
-  budgetAllZones <- json$layout$shapes$y_formula
-  
-  inputs <- get_input()
-  expect_equal(evaluate(budgetAllZones), inputs$budgetAllZones)
-})
-
 test_that("cases averted vs costs graph config x_formula gives correct results", {
   json <- jsonlite::fromJSON(mintr_path("json/graph_cost_cases_averted_config.json"))
   inputs <- get_input()


### PR DESCRIPTION
Remove the red dashed line which was previously shown on the Strategy costs vs Cases averted graph