### PR TITLE
mrc-3227_v2 Config for reinstated historic IRS option

### DIFF
--- a/docker/run_app
+++ b/docker/run_app
@@ -3,6 +3,6 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
-export MINT_BRANCH=master
+export MINT_BRANCH=mrc-3224
 
 docker-compose up -d --quiet-pull

--- a/inst/json/baseline_options.json
+++ b/inst/json/baseline_options.json
@@ -241,7 +241,7 @@
           "controls": [
             {
               "name": "sprayInput",
-              "label": "IRS population coverage at last survey (%)",
+              "label": "IRS population coverage in last survey (%)",
               "type": "select",
               "excludeNullOption": true,
               "required": true,
@@ -265,7 +265,7 @@
           ]
         }
       ],
-      "documentation": "<p>The endemicity of a setting is determined by the mosquito ecology, community activities and environment but also the historic pressure from interventions that are controlling malaria transmission. Therefore, please answer the following questions to put the zone into context.</p><strong>ITN population usage in last survey (%)</strong><p>This can be found from Demographic Health Surveys or other surveys on net use completed in this zone</p><strong>IRS population coverage at last survey (%)</strong><p>This can be found from historical surveys recording the percentage of sleeping structures sprayed in the year of the last survey in this zone.</p>"
+      "documentation": "<p>The endemicity of a setting is determined by the mosquito ecology, community activities and environment but also the historic pressure from interventions that are controlling malaria transmission. Therefore, please answer the following questions to put the zone into context.</p><strong>ITN population usage in last survey (%)</strong><p>This can be found from Demographic Health Surveys or other surveys on net use completed in this zone</p><strong>IRS population coverage in last survey (%)</strong><p>This can be found from historical surveys recording the percentage of sleeping structures sprayed in the year of the last survey in this zone.</p>"
     }
   ]
 }

--- a/inst/json/baseline_options.json
+++ b/inst/json/baseline_options.json
@@ -241,12 +241,12 @@
           "controls": [
             {
               "name": "sprayInput",
-              "label": "What was the estimated coverage of spray campaign (last year)",
+              "label": "IRS population coverage at last survey (%)",
               "type": "select",
               "excludeNullOption": true,
               "required": true,
               "value": "0%",
-              "helpText": "If IRS was not used in the past year, select 0% coverage",
+              "helpText": "The current endemicity of a zone is partly determined by the performance and quantity of vector control leading up to now. This is required to approximate the efficacy of interventions moving forward.",
               "options": [
                 {
                   "id": "0%",
@@ -265,7 +265,7 @@
           ]
         }
       ],
-      "documentation": "<p>The endemicity of a setting is determined by the mosquito ecology, community activities and environment but also the historic pressure from interventions that are controlling malaria transmission. Therefore, please answer the following questions to put the zone into context.</p><strong>ITN population usage in last survey (%)</strong><p>This can be found from Demographic Health Surveys or other surveys on net use completed in this zone</p>"
+      "documentation": "<p>The endemicity of a setting is determined by the mosquito ecology, community activities and environment but also the historic pressure from interventions that are controlling malaria transmission. Therefore, please answer the following questions to put the zone into context.</p><strong>ITN population usage in last survey (%)</strong><p>This can be found from Demographic Health Surveys or other surveys on net use completed in this zone</p><strong>IRS population coverage at last survey (%)</strong><p>This can be found from historical surveys recording the percentage of sleeping structures sprayed in the year of the last survey in this zone.</p>"
     }
   ]
 }

--- a/tests/e2e/baseline.etest.ts
+++ b/tests/e2e/baseline.etest.ts
@@ -18,3 +18,19 @@ test("expected baseline options exist", async ({page}) => {
     await expectOptionLabelAndName(rows.nth(7), "ITN population usage in last survey (%)", "itnUsage");
     await expectOptionLabelAndName(rows.nth(8), "IRS population coverage in last survey (%)", "itnUsage");
 });
+
+test("expected past ITN usage options exist", async({page}) => {
+    const options = await page.locator("select[name='itnUsage'] option");
+    await expectOptionLabelAndName(options.nth(0), "0% usage", "0%");
+    await expectOptionLabelAndName(options.nth(1), "20% usage", "20%");
+    await expectOptionLabelAndName(options.nth(2), "40% usage", "40%");
+    await expectOptionLabelAndName(options.nth(3), "60% usage", "60%");
+    await expectOptionLabelAndName(options.nth(4), "80% usage", "80%");
+});
+
+test("expected past IRS coverage options exist", async ({page}) => {
+    const options = await page.locator("select[name='sprayInput'] option");
+    await expectOptionLabelAndName(options.nth(0), "0% coverage", "0%");
+    await expectOptionLabelAndName(options.nth(1), "20% coverage", "60%");
+    await expectOptionLabelAndName(options.nth(2), "40% coverage", "80%");
+});

--- a/tests/e2e/baseline.etest.ts
+++ b/tests/e2e/baseline.etest.ts
@@ -16,4 +16,5 @@ test("expected baseline options exist", async ({page}) => {
     await expectOptionLabelAndName(rows.nth(5), "Level of pyrethroid resistance", "levelOfResistance");
     await expectOptionLabelAndName(rows.nth(6), "Evidence of PBO synergy", "metabolic");
     await expectOptionLabelAndName(rows.nth(7), "ITN population usage in last survey (%)", "itnUsage");
+    await expectOptionLabelAndName(rows.nth(8), "IRS population coverage in last survey (%)", "itnUsage");
 });

--- a/tests/e2e/baseline.etest.ts
+++ b/tests/e2e/baseline.etest.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import {newProject, expectOptionLabelAndName} from "./helpers";
+import {newProject, expectOptionLabelAndName, expectSelectOptionLabelAndValue} from "./helpers";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -16,21 +16,21 @@ test("expected baseline options exist", async ({page}) => {
     await expectOptionLabelAndName(rows.nth(5), "Level of pyrethroid resistance", "levelOfResistance");
     await expectOptionLabelAndName(rows.nth(6), "Evidence of PBO synergy", "metabolic");
     await expectOptionLabelAndName(rows.nth(7), "ITN population usage in last survey (%)", "itnUsage");
-    await expectOptionLabelAndName(rows.nth(8), "IRS population coverage in last survey (%)", "itnUsage");
+    await expectOptionLabelAndName(rows.nth(8), "IRS population coverage in last survey (%)", "sprayInput");
 });
 
 test("expected past ITN usage options exist", async({page}) => {
     const options = await page.locator("select[name='itnUsage'] option");
-    await expectOptionLabelAndName(options.nth(0), "0% usage", "0%");
-    await expectOptionLabelAndName(options.nth(1), "20% usage", "20%");
-    await expectOptionLabelAndName(options.nth(2), "40% usage", "40%");
-    await expectOptionLabelAndName(options.nth(3), "60% usage", "60%");
-    await expectOptionLabelAndName(options.nth(4), "80% usage", "80%");
+    await expectSelectOptionLabelAndValue(options.nth(0), "0% usage", "0%");
+    await expectSelectOptionLabelAndValue(options.nth(1), "20% usage", "20%");
+    await expectSelectOptionLabelAndValue(options.nth(2), "40% usage", "40%");
+    await expectSelectOptionLabelAndValue(options.nth(3), "60% usage", "60%");
+    await expectSelectOptionLabelAndValue(options.nth(4), "80% usage", "80%");
 });
 
 test("expected past IRS coverage options exist", async ({page}) => {
     const options = await page.locator("select[name='sprayInput'] option");
-    await expectOptionLabelAndName(options.nth(0), "0% coverage", "0%");
-    await expectOptionLabelAndName(options.nth(1), "20% coverage", "60%");
-    await expectOptionLabelAndName(options.nth(2), "40% coverage", "80%");
+    await expectSelectOptionLabelAndValue(options.nth(0), "0% coverage", "0%");
+    await expectSelectOptionLabelAndValue(options.nth(1), "60% coverage", "60%");
+    await expectSelectOptionLabelAndValue(options.nth(2), "80% coverage", "80%");
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -95,8 +95,8 @@ export const expectOptionLabelAndName = async (optionRow, expectedLabel, expecte
 
 export const expectSelectOptionLabelAndValue = async (option, expectedLabel, expectedValue) => {
     const label = await option.innerText();
-    await expect(label).toBe(expectedLabel);
-    const value = option.getAttribute("value");
+    await expect(label.trim()).toBe(expectedLabel);
+    const value = await option.getAttribute("value");
     await expect(value).toBe(expectedValue);
 };
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -93,6 +93,13 @@ export const expectOptionLabelAndName = async (optionRow, expectedLabel, expecte
     await expect(name).toBe(expectedName)
 };
 
+export const expectSelectOptionLabelAndValue = async (option, expectedLabel, expectedValue) => {
+    const label = await option.innerText();
+    await expect(label).toBe(expectedLabel);
+    const value = option.getAttribute("value");
+    await expect(value).toBe(expectedValue);
+};
+
 export const expectPlotDataSummarySeries = async (summary, expectedId, expectedName, expectedType, expectedCount,
                                                   expectedXFirst, expectedXLast, expectedYMin, expectedYMax, yTolerance = null) => {
     await expect(await summary.getAttribute("name")).toBe(expectedName);


### PR DESCRIPTION
Second attempt at this ticket, for new dataset. Updates documentation for historic IRS baseline option. 
This PR is paired with MINT PR: https://github.com/mrc-ide/mint/pull/118
..which un-hides the reinstated options. These PRs should be merged together, 

Both branches are currently deployed to https://mint-dev.dide.ic.ac.uk/