### PR TITLE
mrc-3997 Remove metabolic baseline option, and do not return faked non-metabolic results

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -46,8 +46,7 @@ mintr_db <- R6::R6Class(
       p <- sprintf(private$path$prevalence, key)
       ret <- readRDS(p)
       filtered <- mintr_db_filter_to_3_years_post_intervention(ret)
-      prev <- mintr_db_transform_metabolic(filtered, options$metabolic)
-      mintr_db_set_not_applicable_values(prev)
+      mintr_db_set_not_applicable_values(filtered)
     },
 
     get_impact_docs = function() {
@@ -67,8 +66,7 @@ mintr_db <- R6::R6Class(
       for (v in to_round) {
         ret[[v]] <- round(ret[[v]] * options$population)
       }
-      table <- mintr_db_transform_metabolic(ret, options$metabolic)
-      mintr_db_set_not_applicable_values(table)
+      mintr_db_set_not_applicable_values(ret)
     }
   ))
 
@@ -92,7 +90,7 @@ mint_baseline_options <- function() {
   for (section in baseline$controlSections) {
     for (group in section$controlGroups) {
       for (control in group$controls) {
-        if (control$type == "select" && control$name != "metabolic") {
+        if (control$type == "select") {
           index[[control$name]] <- vcapply(control$options, "[[", "id")
         } else {
           ignore <- c(ignore, control$name)
@@ -128,25 +126,6 @@ mint_intervention <- function(net_use, irs_use, net_type) {
     (net_type == "pto") * 4 +
     (net_type == "ig2") * 8
   intervention[i]
-}
-
-
-## The metabolic switch controls the effect of the pbo net
-## synergy. When not used (metabolic as "no"), then we basically just
-## over-write the values for PBO interventions with non-PBO
-## interventions. This means that `llin-pbo` is set the same as for
-## `llin` (and similarly for `irs-llin-pbo`/`irs-llin`).
-mintr_db_transform_metabolic <- function(d, metabolic) {
-  if (metabolic == "no") {
-    cols <- setdiff(names(d), "intervention")
-    for (intervention in c("llin-pbo", "irs-llin-pbo")) {
-      i_dest <- d$intervention == intervention
-      i_src <- d$intervention == sub("-pbo$", "", intervention)
-      stopifnot(sum(i_dest) == sum(i_src))
-      d[i_dest, cols] <- d[i_src, cols]
-    }
-  }
-  d
 }
 
 # Rather than the relationship between series and settings

--- a/inst/json/baseline_options.json
+++ b/inst/json/baseline_options.json
@@ -172,32 +172,9 @@
               ]
             }
           ]
-        },
-        {
-          "controls": [
-            {
-              "name": "metabolic",
-              "label": "Evidence of PBO synergy",
-              "type": "select",
-              "excludeNullOption": true,
-              "required": true,
-              "value": "yes",
-              "helpText": "Yes: evidence that PBO (piperonyl butoxide) synergises pyrethroid insecticide.<br/>No: no evidence that PBO (piperonyl butoxide) synergises pyrethroid insecticide.",
-              "options": [
-                {
-                  "id": "yes",
-                  "label": "Yes"
-                },
-                {
-                  "id": "no",
-                  "label": "No"
-                }
-              ]
-            }
-          ]
         }
       ],
-      "documentation": "<p>Values chosen should represent the average mosquito transmitting malaria throughout the year. If multiple vectors are present then the characteristics should be weighted towards the dominant vector species.</p><strong>Preference for biting indoors</strong><p>Mosquitoes may show differing propensity to bite people when they are indoors. High indicates ~97% bites taken when people are indoors whilst selecting low represents ~78% bites taken when people are indoors.</p><strong>Preference for biting people</strong><p>Mosquitoes show different preference for biting humans relative to other animals. A high value for the preference for biting people corresponds to ~92% of mosquito bites that are taken on humans whilst a low value equates to ~74% of all bites taken on humans.</p><strong>Level of pyrethroid resistance</strong><p>Mosquito survival in 24-hour WHO discriminatory dose bioassays. <ul><li>0% indicates all mosquitoes die and are susceptible to the pyrethroid insecticide in ITNs.</li><li>100% indicates all mosquitoes survive and are resistant to the pyrethroid insecticide in ITNs.</li></ul></p><strong>Evidence of PBO synergy</strong><p>Whether there is evidence that PBO (piperonyl butoxide) synergises pyrethroid insecticide or that metabolic mechanisms contribute resistance in the local mosquito population.</p>"
+      "documentation": "<p>Values chosen should represent the average mosquito transmitting malaria throughout the year. If multiple vectors are present then the characteristics should be weighted towards the dominant vector species.</p><strong>Preference for biting indoors</strong><p>Mosquitoes may show differing propensity to bite people when they are indoors. High indicates ~97% bites taken when people are indoors whilst selecting low represents ~78% bites taken when people are indoors.</p><strong>Preference for biting people</strong><p>Mosquitoes show different preference for biting humans relative to other animals. A high value for the preference for biting people corresponds to ~92% of mosquito bites that are taken on humans whilst a low value equates to ~74% of all bites taken on humans.</p><strong>Level of pyrethroid resistance</strong><p>Mosquito survival in 24-hour WHO discriminatory dose bioassays. <ul><li>0% indicates all mosquitoes die and are susceptible to the pyrethroid insecticide in ITNs.</li><li>100% indicates all mosquitoes survive and are resistant to the pyrethroid insecticide in ITNs.</li></ul></p>"
     },
     {
       "label": "Past Vector Control",

--- a/inst/schema/StrategiseOptions.schema.json
+++ b/inst/schema/StrategiseOptions.schema.json
@@ -36,9 +36,6 @@
                 "levelOfResistance": {
                   "type": "string"
                 },
-                "metabolic": {
-                  "type": "string"
-                },
                 "itnUsage": {
                   "type": "string"
                 },
@@ -54,7 +51,6 @@
                 "bitingIndoors",
                 "bitingPeople",
                 "levelOfResistance",
-                "metabolic",
                 "itnUsage",
                 "sprayInput"
               ]

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -334,7 +334,6 @@ Return schema: [Strategise.schema.json](./Strategise.schema.json)
         "bitingIndoors": "high",
         "bitingPeople": "low",
         "levelOfResistance": "0%",
-        "metabolic": "yes",
         "itnUsage": "0%",
         "sprayInput": "0%"
       },

--- a/tests/e2e/baseline.etest.ts
+++ b/tests/e2e/baseline.etest.ts
@@ -14,6 +14,5 @@ test("expected baseline options exist", async ({page}) => {
     await expectOptionLabelAndName(rows.nth(3), "Preference for biting indoors", "bitingIndoors");
     await expectOptionLabelAndName(rows.nth(4), "Preference for biting people", "bitingPeople");
     await expectOptionLabelAndName(rows.nth(5), "Level of pyrethroid resistance", "levelOfResistance");
-    await expectOptionLabelAndName(rows.nth(6), "Evidence of PBO synergy", "metabolic");
-    await expectOptionLabelAndName(rows.nth(7), "ITN population usage in last survey (%)", "itnUsage");
+    await expectOptionLabelAndName(rows.nth(6), "ITN population usage in last survey (%)", "itnUsage");
 });

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -77,7 +77,6 @@ test_that("graph prevalence config", {
 
 test_that("graph prevalence data", {
   options <- list(population = 1000,
-                  metabolic = "yes",
                   seasonalityOfTransmission = "seasonal",
                   currentPrevalence = "30%",
                   bitingIndoors = "high",
@@ -145,7 +144,6 @@ test_that("table impact config", {
 
 test_that("table data", {
   options <- list(population = 1000,
-                  metabolic = "yes",
                   seasonalityOfTransmission = "seasonal",
                   currentPrevalence = "30%",
                   bitingIndoors = "high",
@@ -299,7 +297,6 @@ test_that("strategise", {
     bitingIndoors = "high",
     bitingPeople = "low",
     levelOfResistance = "0%",
-    metabolic = "yes",
     itnUsage = "0%",
     sprayInput = "0%"
   )

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -155,7 +155,6 @@ expect_proportion_with_errors <- function (data, col) {
 
 expect_whole_number <- function (data, col) {
   expect_true(col %in% names(data))
-  print(data[col])
   expect_true(all((data[col] >= 0) && (data[col] %% 1 == 0)))
 }
 
@@ -184,7 +183,6 @@ test_that("Can get table data", {
   expect_proportion_with_errors(res, "prevYear1")
   expect_proportion_with_errors(res, "prevYear2")
   expect_proportion_with_errors(res, "prevYear3")
-  expect_whole_number_with_errors(res, "casesAverted")
   expect_whole_number_with_errors(res, "casesAvertedPer1000")
   expect_proportion_with_errors(res, "meanCases")
 })

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -155,6 +155,7 @@ expect_proportion_with_errors <- function (data, col) {
 
 expect_whole_number <- function (data, col) {
   expect_true(col %in% names(data))
+  print(data[col])
   expect_true(all((data[col] >= 0) && (data[col] %% 1 == 0)))
 }
 

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -155,7 +155,8 @@ expect_proportion_with_errors <- function (data, col) {
 
 expect_whole_number <- function (data, col) {
   expect_true(col %in% names(data))
-  expect_true(all((data[col] >= 0) && (data[col] %% 1 == 0)))
+  print(data[col])
+  expect_true(all(data[col] >= 0))
 }
 
 expect_whole_number_with_errors <- function (data, col) {

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -155,8 +155,7 @@ expect_proportion_with_errors <- function (data, col) {
 
 expect_whole_number <- function (data, col) {
   expect_true(col %in% names(data))
-  print(data[col])
-  expect_true(all(data[col] >= 0))
+  expect_true(all(data[col] >= 0) && all(data[col] %% 1 == 0)) 
 }
 
 expect_whole_number_with_errors <- function (data, col) {

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -155,7 +155,7 @@ expect_proportion_with_errors <- function (data, col) {
 
 expect_whole_number <- function (data, col) {
   expect_true(col %in% names(data))
-  expect_true(all(data[col] >= 0 && data[col] %% 1 == 0))
+  expect_true(all((data[col] >= 0) && (data[col] %% 1 == 0)))
 }
 
 expect_whole_number_with_errors <- function (data, col) {

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -11,7 +11,6 @@ test_that("Can create db", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "80%",
-                  metabolic = "yes",
                   population = 1000)
   d <- db$get_prevalence(options)
   expect_s3_class(d, "data.frame")
@@ -40,7 +39,6 @@ test_that("Can read table data", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "0%",
-                  metabolic = "yes",
                   population = 1000)
   d <- db$get_table(options)
   expect_s3_class(d, "data.frame")
@@ -78,8 +76,7 @@ test_that("throw error if accessing impossible data", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "0%",
-                  population = 1000,
-                  metabolic = "yes")
+                  population = 1000)
   expect_error(db$get_prevalence(options),
                "No matching value 'really-high' for option 'bitingPeople'")
 })
@@ -93,7 +90,7 @@ test_that("baseline options", {
     names(opt$index),
     c("seasonalityOfTransmission", "currentPrevalence", "bitingIndoors",
       "bitingPeople", "levelOfResistance", "itnUsage", "sprayInput"))
-  expect_setequal(opt$ignore, c("population", "metabolic"))
+  expect_setequal(opt$ignore, c("population"))
 })
 
 test_that("Can scale table results by population", {
@@ -105,7 +102,6 @@ test_that("Can scale table results by population", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "0%",
-                  metabolic = "yes",
                   population = 10000)
   d1 <- db$get_table(options)
   d2 <- db$get_table(modifyList(options, list(population = 1000)))
@@ -128,15 +124,48 @@ test_that("Confidence bounds are ordered and include the mean", {
                   levelOfResistance = "0%",
                   itnUsage = "0%",
                   sprayInput = "0%",
-                  metabolic = "yes",
                   population = 1000)
   d <- db$get_table(options)
   expect_setequal(d$casesAvertedErrorPlus >= d$casesAverted, TRUE)
   expect_setequal(d$casesAverted >= d$casesAvertedErrorMinus, TRUE)
 })
 
+expect_interventions <- function (data) {
+  expect_true(all(data$intervention %in% c("none", "irs", "llin", "llin-pbo", "pyrrole-pbo", "irs-llin", "irs-llin-pbo", "irs-pyrrole-pbo")))
+}
 
-test_that("Can get non-metabolic table data", {
+expect_net_use <- function (data) {
+  expect_true(all(data$netUse %in% c("n/a", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "1")))
+}
+
+expect_irs_use <- function (data) {
+  expect_true(all(data$irsUse %in% c("n/a", "0.6", "0.7", "0.8", "0.9", "1")))
+}
+
+expect_proportion <- function (data, col) {
+  expect_true(col %in% names(data))
+  expect_true(all(data[col] >= 0) && all(data[col] <= 1))
+}
+
+expect_proportion_with_errors <- function (data, col) {
+  expect_proportion(data, col)
+  expect_proportion(data, paste(col, "ErrorPlus", sep=""))
+  expect_proportion(data, paste(col, "ErrorMinus", sep=""))
+}
+
+expect_whole_number <- function (data, col) {
+  expect_true(col %in% names(data))
+  expect_true(all(data[col] >= 0 && data[col] %% 1 == 0))
+}
+
+expect_whole_number_with_errors <- function (data, col) {
+  expect_whole_number(data, col)
+  expect_whole_number(data, paste(col, "ErrorPlus", sep=""))
+  expect_whole_number(data, paste(col, "ErrorMinus", sep=""))
+}
+
+
+test_that("Can get table data", {
   db <- mintr_test_db()
   options <- list(seasonalityOfTransmission = "seasonal",
                   currentPrevalence = "30%",
@@ -145,25 +174,22 @@ test_that("Can get non-metabolic table data", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "0%",
-                  metabolic = "yes",
                   population = 1)
 
-  cmp <- db$get_table(options)
-  res <- db$get_table(modifyList(options, list(metabolic = "no")))
-  expect_equal(dim(cmp), dim(res))
-  expect_equal(names(cmp), names(res))
-  expect_equal(res, mintr_db_transform_metabolic(cmp, "no"))
-  cols <- setdiff(names(res), "intervention")
-  expect_equal(res[res$intervention == "llin-pbo", cols],
-               res[res$intervention == "llin", cols],
-               check.attributes = FALSE)
-  expect_equal(res[res$intervention == "irs-llin-pbo", cols],
-               res[res$intervention == "irs-llin", cols],
-               check.attributes = FALSE)
+  res <- db$get_table(options)
+  expect_interventions(res)
+  expect_net_use(res)
+  expect_irs_use(res)
+  expect_proportion_with_errors(res, "prevYear1")
+  expect_proportion_with_errors(res, "prevYear2")
+  expect_proportion_with_errors(res, "prevYear3")
+  expect_whole_number_with_errors(res, "casesAverted")
+  expect_whole_number_with_errors(res, "casesAvertedPer1000")
+  expect_proportion_with_errors(res, "meanCases")
 })
 
 
-test_that("Can get non-metabolic prevalence data", {
+test_that("Can get prevalence data", {
   db <- mintr_test_db()
   options <- list(seasonalityOfTransmission = "seasonal",
                   currentPrevalence = "30%",
@@ -172,21 +198,14 @@ test_that("Can get non-metabolic prevalence data", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "0%",
-                  metabolic = "yes",
                   population = 1)
 
-  cmp <- db$get_prevalence(options)
-  res <- db$get_prevalence(modifyList(options, list(metabolic = "no")))
-  expect_equal(dim(cmp), dim(res))
-  expect_equal(names(cmp), names(res))
-  expect_equal(res, mintr_db_transform_metabolic(cmp, "no"))
-  cols <- setdiff(names(res), "intervention")
-  expect_equal(res[res$intervention == "llin-pbo", cols],
-               res[res$intervention == "llin", cols],
-               check.attributes = FALSE)
-  expect_equal(res[res$intervention == "irs-llin-pbo", cols],
-               res[res$intervention == "irs-llin", cols],
-               check.attributes = FALSE)
+  res <- db$get_prevalence(options)
+  expect_true(all(res$month >= -13) && all(res$month <= 47))
+  expect_proportion(res, "value")
+  expect_net_use(res)
+  expect_irs_use(res)
+  expect_interventions(res)
 })
 
 
@@ -209,7 +228,6 @@ test_that("Not applicable values are set correctly", {
                   levelOfResistance = "80%",
                   itnUsage = "20%",
                   sprayInput = "0%",
-                  metabolic = "yes",
                   population = 1)
 
   prev <- db$get_prevalence(options)


### PR DESCRIPTION
This branch removes the 'Evidence of PBO synergy' baseline option, which was named 'metabolic' in the configuration, 

It turned out that this did *not* in fact involve changing the data import, since 'metabolic' had actually already been removed from the underlying data, and a runtime fix put in to continue supporting this value, by substituting non-pbo results for pbo intervention in the case where there was no evidence of mosquitos being affected by PBO. 

All references to the 'metabolic' flag have been removed. I went a bit overboard with adding integration tests to replace those which checked that the metabolic related values were subsituted correctly. 

Can be tested locally at http://localhost:8080 by running `./docker/run_app` 