### PR TITLE
Remove trailing comma from emulator schema

### DIFF
--- a/inst/schema/EmulatorOptions.schema.json
+++ b/inst/schema/EmulatorOptions.schema.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
+  "type": "object"
 }


### PR DESCRIPTION
I'm honestly not sure how this even made it through CI. Either the JSON parser we use is extremely lax or we never actually read them. I'll have to look into this later.