### PR TITLE
Mrc-6656 Run emulator model runs for cases and prevelance

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, ropensci/piggyback, local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, ropensci/piggyback, local::.
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Imports:
     rmpk,
     ROIoptimizer,
     ROI.plugin.glpk,
-    tidyr
+    tidyr,
+    MINTer
 Suggests:
     fs,
     glue,
@@ -34,6 +35,7 @@ Remotes:
     reside-ic/porcelain,
     ropensci/jsonvalidate,
     r-opt/rmpk,
-    r-opt/ROIoptimizer
+    r-opt/ROIoptimizer,
+    CosmoNaught/MINTer
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3

--- a/R/api.R
+++ b/R/api.R
@@ -21,7 +21,7 @@ api_build <- function(db, emulator_root=NULL) {
   pr$handle(endpoint_cost_intepretation(db))
   pr$handle(endpoint_strategise(db))
   pr$handle(endpoint_version())
-  pr$handle(endpoint_emulator_process())
+  pr$handle(endpoint_emulator_run())
   if (!is.null(emulator_root)) {
     pr$handle(endpoint_emulator_config(emulator_root))
     pr$handle(endpoint_emulator_model(emulator_root))
@@ -257,17 +257,15 @@ target_strategise <- function(db) {
   }
 }
 
-endpoint_emulator_process <- function() {
+endpoint_emulator_run <- function() {
   porcelain::porcelain_endpoint$new(
-    "POST", "/emulator/process", target_emulator_process,
+    "POST", "/emulator/run", target_emulator_run,
     porcelain::porcelain_input_body_json("options", "EmulatorOptions"),
     returning = porcelain::porcelain_returning_json("EmulatorResults"))
 }
 
-target_emulator_process <- function() {
-  function(options) {
-    run_emulator(jsonlite::fromJSON(options))
-  }
+target_emulator_run <- function(options) {
+    run_emulator(jsonlite::fromJSON(options))  
 }
 
 # TODO: remove all old emulator references

--- a/R/api.R
+++ b/R/api.R
@@ -21,6 +21,7 @@ api_build <- function(db, emulator_root=NULL) {
   pr$handle(endpoint_cost_intepretation(db))
   pr$handle(endpoint_strategise(db))
   pr$handle(endpoint_version())
+  pr$handle(endpoint_emulator_process())
   if (!is.null(emulator_root)) {
     pr$handle(endpoint_emulator_config(emulator_root))
     pr$handle(endpoint_emulator_model(emulator_root))
@@ -28,6 +29,7 @@ api_build <- function(db, emulator_root=NULL) {
   pr
 }
 
+# TODO: remove all old endpoints later
 
 ## Every endpoint comes as a pair of functions:
 ##
@@ -255,6 +257,20 @@ target_strategise <- function(db) {
   }
 }
 
+endpoint_emulator_process <- function() {
+  porcelain::porcelain_endpoint$new(
+    "POST", "/emulator/process", target_emulator_process,
+    porcelain::porcelain_input_body_json("options", "EmulatorOptions"),
+    returning = porcelain::porcelain_returning_json("EmulatorResults"))
+}
+
+target_emulator_process <- function() {
+  function(options) {
+    run_emulator(jsonlite::fromJSON(options))
+  }
+}
+
+# TODO: remove all old emulator references
 endpoint_emulator_config <- function(emulator_root) {
   porcelain::porcelain_endpoint$new(
     "GET", "/emulator/config", target_emulator_config(emulator_root),

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -3,10 +3,10 @@ run_emulator <- function(options) {
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 
-    list(
-        cases = c(),
-        prevalence = c()
-    )
+    results <- do.call(MINTer::run_mint_scenarios, minter_params)
+    # post-process results
+
+    post_process_results(results)
 }
 
 transform_options <- function(options) {
@@ -121,4 +121,13 @@ build_minter_params <- function(options) {
     }
 
     minter_params
+}
+
+post_process_results <- function(results) {
+    # prevalence time steps are weekly
+    days_in_week <- 7
+    results$prevalence <- results$prevalence |> dplyr::group_by(scenario) |> dplyr::mutate(days = row_number() * days_in_week)
+    results$cases <- results$cases |> dplyr::group_by(scenario) |> dplyr::mutate(year = row_number())
+    
+    results
 }

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -124,10 +124,15 @@ build_minter_params <- function(options) {
 post_process_results <- function(results) {
     # prevalence time steps are weekly
     days_in_week <- 7
+    days_in_year <- 365
     results$prevalence <- results$prevalence |>
         dplyr::mutate(days = row_number() * days_in_week, .by = scenario)
     results$cases <- results$cases |>
-        dplyr::mutate(year = row_number(), .by = scenario)
+        dplyr::mutate(
+            year = row_number(),
+            cases_per_1000 = cases_per_1000 * days_in_year,
+            .by = scenario
+        )
 
     results
 }

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -127,10 +127,10 @@ post_process_results <- function(results) {
     days_in_year <- 365
     results$prevalence <- results$prevalence |>
         dplyr::mutate(days = row_number() * days_in_week, .by = scenario)
-    results$cases <- results$cases |>
+    results$cases <- results$cases |> rename(casesPer1000 = cases_per_1000) |>
         dplyr::mutate(
             year = row_number(),
-            cases_per_1000 = cases_per_1000 * days_in_year,
+            casesPer1000 = casesPer1000 * days_in_year,
             .by = scenario
         )
 

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -1,5 +1,6 @@
 run_emulator <- function(options) {
     transformed_options <- transform_options(options)
+    print(transformed_options) # TODO: remove
     minter_params <- build_minter_params(transformed_options)
 
     results <- do.call(MINTer::run_mint_scenarios, minter_params)

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -124,8 +124,10 @@ build_minter_params <- function(options) {
 post_process_results <- function(results) {
     # prevalence time steps are weekly
     days_in_week <- 7
-    results$prevalence <- results$prevalence |> dplyr::group_by(scenario) |> dplyr::mutate(days = row_number() * days_in_week)
-    results$cases <- results$cases |> dplyr::group_by(scenario) |> dplyr::mutate(year = row_number())
-    
+    results$prevalence <- results$prevalence |>
+        dplyr::mutate(days = row_number() * days_in_week, .by = scenario)
+    results$cases <- results$cases |>
+        dplyr::mutate(year = row_number(), .by = scenario)
+
     results
 }

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -5,7 +5,7 @@ run_emulator <- function(options) {
     results <- do.call(MINTer::run_mint_scenarios, minter_params)
     # post-process results
 
-    print(head(results))
+    print(head(results)) # TODO: remove
     post_process_results(results)
 }
 

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -1,5 +1,4 @@
 run_emulator <- function(options) {
-library(MINTer) # TODO: test and remove if needed
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -1,0 +1,124 @@
+# TODO: update naming and make clearer.
+run_emulator <- function(options) {
+    transformed_options <- transform_options(options)
+    minter_params <- build_minter_params(transformed_options)
+
+    minter_params
+}
+
+transform_options <- function(options) {
+  list(
+  # baseline 
+  res_use = options$pyrethroid_resistance/100,
+  py_only = options$py_only/100,
+  py_pbo = options$py_pbo/100,
+  py_pyrrole = options$py_pyrrole/100,
+  py_ppf = options$py_ppf/100,
+  prev = options$current_malaria_prevalence/100,
+  Q0 = options$preference_for_biting/100,
+  phi = options$preference_for_biting_in_bed/100,
+  season = as.integer(options$is_seasonal),
+  irs = options$irs_coverage/100,
+  # intervention
+  itn_future = options$itn_future/100,
+  net_type_future = options$itn_future_types,
+  irs_future = options$irs_future/100,
+  routine = as.integer(options$routine_coverage),
+  lsm = options$lsm/100
+ )
+}
+
+# Helper: create the baseline (no intervention) scenario
+create_base_scenario <- function(options) {
+  list(
+    scenario_tag   = "no_intervention",
+    res_use        = options$res_use,
+    py_only        = options$py_only,
+    py_pbo         = options$py_pbo,
+    py_pyrrole     = options$py_pyrrole,
+    py_ppf         = options$py_ppf,
+    prev           = options$prev,
+    Q0             = options$Q0,
+    phi            = options$phi,
+    season         = options$season,
+    irs            = options$irs,
+    # no intervention
+    itn_future     = 0,
+    net_type_future= NA_character_,
+    irs_future     = 0,
+    routine        = 0,
+    lsm            = 0
+  )
+}
+
+# Helper: override selected fields in scenario
+with_overrides <- function(scenario, overrides) {
+    for (field in names(overrides)) {
+        scenario[[field]] <- overrides[[field]]
+    }
+    scenario
+}
+# Helper: append a scenario row to the accumulator (column-wise concat)
+append_scenario <- function(accumulator, scenario) {
+    Map(c, accumulator, scenario)
+}
+
+build_minter_params <- function(options) {
+    # TODO: will update as cosmo model updates
+    year_start <- 2
+    year_end <- 5
+    base_scenario <- create_base_scenario(options)
+    minter_params <- base_scenario
+
+    # irs only
+    if (options$irs_future > 0) {
+        irs_only_scenario <- with_overrides(
+            base_scenario,
+            list(
+                scenario_tag = "irs_only",
+                irs_future = options$irs_future
+            )
+        )
+        minter_params <- append_scenario(minter_params, irs_only_scenario)
+    }
+
+    # lsm only
+    if (options$lsm > 0) {
+        lsm_only_scenario <- with_overrides(
+            base_scenario,
+            list(
+                scenario_tag = "lsm_only",
+                lsm = options$lsm
+            )
+        )
+        minter_params <- append_scenario(minter_params, lsm_only_scenario)
+    }
+
+    # net-type scenarios (and with lsm)
+    for (net_type in options$net_type_future) {
+        net_type_scenario <- with_overrides(
+            base_scenario,
+            list(
+                scenario_tag = paste0(net_type, "_only"),
+                net_type_future = net_type,
+                itn_future = options$itn_future,
+                routine = options$routine
+            )
+        )
+        minter_params <- append_scenario(minter_params, net_type_scenario)
+
+        # net with lsm
+        if (options$lsm > 0) {
+            net_type_lsm_scenario <- with_overrides(
+                net_type_scenario,
+                list(
+                    scenario_tag = paste0(net_type, "_with_lsm"),
+                    lsm = options$lsm
+                )
+            )
+            minter_params <- append_scenario(minter_params, net_type_lsm_scenario)
+        }
+    }
+
+    minter_params
+}

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -5,6 +5,7 @@ run_emulator <- function(options) {
     results <- do.call(MINTer::run_mint_scenarios, minter_params)
     # post-process results
 
+    print(head(results))
     post_process_results(results)
 }
 

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -2,7 +2,7 @@ run_emulator <- function(options) {
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 
-    results <- do.call(run_mint_scenarios, minter_params)
+    results <- do.call(MINTer::run_mint_scenarios, minter_params)
     # post-process results
 
     post_process_results(results)

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -3,7 +3,10 @@ run_emulator <- function(options) {
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 
-    minter_params
+    list(
+        cases = c(),
+        prevalence = c()
+    )
 }
 
 transform_options <- function(options) {
@@ -64,9 +67,6 @@ append_scenario <- function(accumulator, scenario) {
 }
 
 build_minter_params <- function(options) {
-    # TODO: will update as cosmo model updates
-    year_start <- 2
-    year_end <- 5
     base_scenario <- create_base_scenario(options)
     minter_params <- base_scenario
 

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -1,9 +1,9 @@
-# TODO: update naming and make clearer.
+library(MINTer) # TODO: test and remove if needed
 run_emulator <- function(options) {
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 
-    results <- do.call(MINTer::run_mint_scenarios, minter_params)
+    results <- do.call(run_mint_scenarios, minter_params)
     # post-process results
 
     post_process_results(results)

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -1,12 +1,9 @@
 run_emulator <- function(options) {
     transformed_options <- transform_options(options)
-    print(transformed_options) # TODO: remove
     minter_params <- build_minter_params(transformed_options)
 
     results <- do.call(MINTer::run_mint_scenarios, minter_params)
-    # post-process results
 
-    print(head(results)) # TODO: remove
     post_process_results(results)
 }
 

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -1,5 +1,5 @@
-library(MINTer) # TODO: test and remove if needed
 run_emulator <- function(options) {
+library(MINTer) # TODO: test and remove if needed
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
+        python3 \
+        python3-pip \
+        python3-venv \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
-
 COPY docker/install_packages /usr/local/bin/
 
 RUN install_packages \
@@ -30,6 +29,7 @@ RUN install_packages \
         tidyr
 
 RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk", "CosmoNaught/MINTer"))'
+RUN Rscript -e 'MINTer::initialize_python()'
 
 WORKDIR /mintr
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@ RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https
 # Optional Python (kept from original)
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
 RUN uv venv
-RUN source .venv/bin/activate
 RUN uv pip install torch numpy pandas scikit-learn
+RUN source .venv/bin/activate
 
 # Pre-install R deps from DESCRIPTION for better caching
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,9 @@ RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https
 
 # Optional Python (kept from original)
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
-RUN uv python install 3.12
+RUN uv env
+RUN source .venv/bin/activate
+RUN uv pip install torch numpy pandas scikit-learn
 
 # Pre-install R deps from DESCRIPTION for better caching
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,12 @@
 FROM rocker/r-ver:latest
 
-# System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
+        && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
-# Configure repos (mrc-ide + CRAN)
-RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https://cloud.r-project.org"))' >> /usr/local/lib/R/etc/Rprofile.site
 
 # Install python dependencies
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
@@ -17,18 +15,34 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN uv pip install torch numpy pandas scikit-learn
 
-# Pre-install R deps from DESCRIPTION for better caching
-WORKDIR /src
-COPY ./DESCRIPTION /src/
-RUN Rscript -e 'install.packages("remotes"); remotes::install_deps("/src", dependencies = TRUE)'
+COPY docker/install_packages /usr/local/bin/
 
-# Copy the rest of the source and install the package
-COPY . /src
-RUN R CMD INSTALL /src
+RUN install_packages \
+        --repo=https://mrc-ide.r-universe.dev \
+        # --repo=https://r-opt.r-universe.dev \
+        R6 \
+        ROI.plugin.glpk \
+        # ROIoptimizer \
+        commonmark \
+        dplyr \
+        glue \
+        jsonlite \
+        jsonvalidate \
+        plumber \
+        porcelain \
+        remotes \
+        # rmpk \
+        testthat \
+        tidyr
 
-# Runtime setup using the installed package
+RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk", "CosmoNaught/MINTer"))'
+
 WORKDIR /mintr
-RUN Rscript -e 'mintr:::write_script("/usr/bin")' && \
+
+COPY . /src
+
+RUN R CMD INSTALL /src && \
+        Rscript -e 'mintr:::write_script("/usr/bin")' && \
         Rscript -e 'mintr:::mintr_db_download("data")'
 
 EXPOSE 8888

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,16 +4,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
+        curl \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
-
-# Install python dependencies with uv
-COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
-RUN uv venv /opt/venv
-ENV VIRTUAL_ENV=/opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-RUN uv pip install --no-cache-dir torch numpy pandas scikit-learn
 
 COPY docker/install_packages /usr/local/bin/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
+        python3 \
+        python3-pip \
+        python3-venv \
+        python-is-python3 \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
-
-COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
-RUN uv python install 3.12
 
 COPY docker/install_packages /usr/local/bin/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
 RUN uv venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN uv pip install torch numpy pandas scikit-learn
+RUN uv pip install --no-cache-dir torch numpy pandas scikit-learn
 
 COPY docker/install_packages /usr/local/bin/
 
@@ -44,6 +44,13 @@ COPY . /src
 RUN R CMD INSTALL /src && \
         Rscript -e 'mintr:::write_script("/usr/bin")' && \
         Rscript -e 'mintr:::mintr_db_download("data")'
+
+# ---------- Runtime stage ----------
+FROM rocker/r-ver:latest
+
+COPY --from=build /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+COPY --from=build /usr/local/bin/mintr /usr/local/bin/mintr
+COPY --from=build /opt/venv /opt/venv
 
 EXPOSE 8888
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,13 +45,6 @@ RUN R CMD INSTALL /src && \
         Rscript -e 'mintr:::write_script("/usr/bin")' && \
         Rscript -e 'mintr:::mintr_db_download("data")'
 
-# ---------- Runtime stage ----------
-FROM rocker/r-ver:latest
-
-COPY --from=build /usr/local/lib/R/site-library /usr/local/lib/R/site-library
-COPY --from=build /usr/local/bin/mintr /usr/local/bin/mintr
-COPY --from=build /opt/venv /opt/venv
-
 EXPOSE 8888
 
 ENTRYPOINT ["/usr/bin/mintr"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https
 
 # Optional Python (kept from original)
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
-RUN uv env
+RUN uv venv
 RUN source .venv/bin/activate
 RUN uv pip install torch numpy pandas scikit-learn
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Configure repos (mrc-ide + CRAN)
 RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https://cloud.r-project.org"))' >> /usr/local/lib/R/etc/Rprofile.site
 
-# Optional Python (kept from original)
+# Install python dependencies
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
-RUN uv venv
+RUN uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 RUN uv pip install torch numpy pandas scikit-learn
-RUN . .venv/bin/activate
 
 # Pre-install R deps from DESCRIPTION for better caching
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
-        python3 \
-        python3-pip \
-        python3-venv \
-        python-is-python3 \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
+
+
+COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
+RUN uv python install 3.12
 
 COPY docker/install_packages /usr/local/bin/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && rm -rf /var/lib/apt/lists/*
 
 
-# Install python dependencies
+# Install python dependencies with uv
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
 RUN uv venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
-        python3 \
-        python3-pip \
-        python3-venv \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
+RUN uv python install 3.12
 
 COPY docker/install_packages /usr/local/bin/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
 RUN uv venv
 RUN uv pip install torch numpy pandas scikit-learn
-RUN source .venv/bin/activate
+RUN . .venv/bin/activate
 
 # Pre-install R deps from DESCRIPTION for better caching
 WORKDIR /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,44 +1,31 @@
 FROM rocker/r-ver:latest
 
+# System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev \
         libv8-dev \
         libglpk-dev \
-        && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
+# Configure repos (mrc-ide + CRAN)
+RUN echo 'options(repos = c(mrcide="https://mrc-ide.r-universe.dev", CRAN="https://cloud.r-project.org"))' >> /usr/local/lib/R/etc/Rprofile.site
 
+# Optional Python (kept from original)
 COPY --from=ghcr.io/astral-sh/uv:0.8.14 /uv /uvx /bin/
 RUN uv python install 3.12
 
-COPY docker/install_packages /usr/local/bin/
+# Pre-install R deps from DESCRIPTION for better caching
+WORKDIR /src
+COPY ./DESCRIPTION /src/
+RUN Rscript -e 'install.packages("remotes"); remotes::install_deps("/src", dependencies = TRUE)'
 
-RUN install_packages \
-        --repo=https://mrc-ide.r-universe.dev \
-        # --repo=https://r-opt.r-universe.dev \
-        R6 \
-        ROI.plugin.glpk \
-        # ROIoptimizer \
-        commonmark \
-        dplyr \
-        glue \
-        jsonlite \
-        jsonvalidate \
-        plumber \
-        porcelain \
-        remotes \
-        # rmpk \
-        testthat \
-        tidyr
-
-RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk", "CosmoNaught/MINTer"))'
-
-WORKDIR /mintr
-
+# Copy the rest of the source and install the package
 COPY . /src
+RUN R CMD INSTALL /src
 
-RUN R CMD INSTALL /src && \
-        Rscript -e 'mintr:::write_script("/usr/bin")' && \
+# Runtime setup using the installed package
+WORKDIR /mintr
+RUN Rscript -e 'mintr:::write_script("/usr/bin")' && \
         Rscript -e 'mintr:::mintr_db_download("data")'
 
 EXPOSE 8888

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN install_packages \
         testthat \
         tidyr
 
-RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk"))'
+RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk", "CosmoNaught/MINTer"))'
 
 WORKDIR /mintr
 

--- a/inst/json/options.json
+++ b/inst/json/options.json
@@ -6,7 +6,7 @@
       "description": "These are the baseline options for the form.",
       "helpText": "Configure the baseline options for the form.",
       "collapsible": true,
-      "triggersRerun": true,
+      "triggersRun": true,
       "preRun": true,
       "subGroups": [
         {
@@ -187,7 +187,7 @@
     {
       "id": "intervention_options",
       "title": "Intervention Options",
-      "triggersRerun": true,
+      "triggersRun": true,
       "collapsible": true,
       "preRun": false,
       "description": "These are the intervention options for the form.",
@@ -273,7 +273,7 @@
       "title": "Cost Options",
       "description": "Cost Options",
       "helpText": "Configure the cost options for the form.",
-      "triggersRerun": false,
+      "triggersRun": false,
       "collapsible": true,
       "preRun": false,
       "subGroups": [

--- a/inst/json/options.json
+++ b/inst/json/options.json
@@ -216,7 +216,7 @@
             {
               "id": "itn_future_types",
               "label": "Future ITN Types",
-              "helpText": "Select the type of ITNs that will be used in the future.",
+              "helpText": "Select the type of ITNs that will be used in the future. Must have Expected ITN population use > 0",
               "type": "multiselect",
               "disabled": {
                 "type": "cross_field",
@@ -233,7 +233,7 @@
             {
               "id": "routine_coverage",
               "label": "Continuous distribution of ITNs",
-              "helpText": "Indicate whether continuous distribution of ITNs will be implemented.",
+              "helpText": "Indicate whether continuous distribution of ITNs will be implemented. Must have Expected ITN population use > 0",
               "type": "toggle",
               "required": true,
               "disabled": {

--- a/inst/json/options.json
+++ b/inst/json/options.json
@@ -216,7 +216,7 @@
             {
               "id": "itn_future_types",
               "label": "Future ITN Types",
-              "helpText": "Select the type of ITNs that will be used in the future. Must have Expected ITN population use > 0",
+              "helpText": "Select the type of ITNs that will be used in the future. This field becomes enabled when Expected ITN population use > 0.",
               "type": "multiselect",
               "disabled": {
                 "type": "cross_field",
@@ -233,7 +233,7 @@
             {
               "id": "routine_coverage",
               "label": "Continuous distribution of ITNs",
-              "helpText": "Indicate whether continuous distribution of ITNs will be implemented. Must have Expected ITN population use > 0",
+              "helpText": "Indicate whether continuous distribution of ITNs will be implemented. This field becomes enabled when Expected ITN population use > 0.",
               "type": "toggle",
               "required": true,
               "disabled": {

--- a/inst/json/options.json
+++ b/inst/json/options.json
@@ -218,6 +218,11 @@
               "label": "Future ITN Types",
               "helpText": "Select the type of ITNs that will be used in the future.",
               "type": "multiselect",
+              "disabled": {
+                "type": "cross_field",
+                "fields": ["itn_future"],
+                "operator": "falsy"
+              },
               "options": [
                 { "label": "Pyrethroid ITNs", "value": "py_only" },
                 { "label": "Pyrethroid-PBO ITNs", "value": "py_pbo" },

--- a/inst/schema/EmulatorOptions.schema.json
+++ b/inst/schema/EmulatorOptions.schema.json
@@ -1,4 +1,82 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object"
+  "title": "EmulatorOptions",
+  "type": "object",
+  "properties": {
+    "triggerRun": { "type": "boolean" },
+    "population": { "type": "integer", "minimum": 0 },
+    "is_seasonal": { "type": "boolean" },
+    "current_malaria_prevalence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "preference_for_biting_in_bed": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "preference_for_biting": { "type": "number", "minimum": 0, "maximum": 100 },
+    "pyrethroid_resistance": { "type": "number", "minimum": 0, "maximum": 100 },
+    "py_only": { "type": "number", "minimum": 0, "maximum": 100 },
+    "py_pbo": { "type": "number", "minimum": 0, "maximum": 100 },
+    "py_pyrrole": { "type": "number", "minimum": 0, "maximum": 100 },
+    "py_ppf": { "type": "number", "minimum": 0, "maximum": 100 },
+    "itn_total": {
+      "type": "null"
+    },
+    "irs_coverage": { "type": "number", "minimum": 0, "maximum": 100 },
+    "itn_future": { "type": "number", "minimum": 0, "maximum": 100 },
+    "itn_future_types": {
+      "type": "array",
+      "items": { "enum": ["py_only", "py_pyrrole", "py_ppf", "py_pbo"] },
+      "uniqueItems": true
+    },
+    "routine_coverage": { "type": "boolean" },
+    "irs_future": { "type": "number", "minimum": 0, "maximum": 100 },
+    "lsm": { "type": "number", "minimum": 0, "maximum": 100 },
+    "people_per_bednet": { "type": "number", "minimum": 0 },
+    "people_per_household": { "type": "integer", "minimum": 1 },
+    "procurement_buffer": { "type": "integer", "minimum": 0 },
+    "py_only_cost": { "type": "number", "minimum": 0 },
+    "py_pbo_cost": { "type": "number", "minimum": 0 },
+    "py_pyrrole_cost": { "type": "number", "minimum": 0 },
+    "py_ppf_cost": { "type": "number", "minimum": 0 },
+    "mass_distribution_cost": { "type": "number", "minimum": 0 },
+    "continuous_itn_distribution_cost": { "type": "number", "minimum": 0 },
+    "irs_household_annual_cost": { "type": "number", "minimum": 0 },
+    "lsm_cost": { "type": "number", "minimum": 0 }
+  },
+  "additionalProperties": false,
+  "required": [
+    "triggerRun",
+    "population",
+    "is_seasonal",
+    "current_malaria_prevalence",
+    "preference_for_biting_in_bed",
+    "preference_for_biting",
+    "pyrethroid_resistance",
+    "py_only",
+    "py_pbo",
+    "py_pyrrole",
+    "py_ppf",
+    "itn_total",
+    "irs_coverage",
+    "itn_future",
+    "itn_future_types",
+    "routine_coverage",
+    "irs_future",
+    "lsm",
+    "people_per_bednet",
+    "people_per_household",
+    "procurement_buffer",
+    "py_only_cost",
+    "py_pbo_cost",
+    "py_pyrrole_cost",
+    "py_ppf_cost",
+    "mass_distribution_cost",
+    "continuous_itn_distribution_cost",
+    "irs_household_annual_cost",
+    "lsm_cost"
+  ]
 }

--- a/inst/schema/EmulatorOptions.schema.json
+++ b/inst/schema/EmulatorOptions.schema.json
@@ -3,7 +3,6 @@
   "title": "EmulatorOptions",
   "type": "object",
   "properties": {
-    "population": { "type": "integer", "minimum": 0 },
     "is_seasonal": { "type": "boolean" },
     "current_malaria_prevalence": {
       "type": "number",
@@ -34,7 +33,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "population",
     "is_seasonal",
     "current_malaria_prevalence",
     "preference_for_biting_in_bed",

--- a/inst/schema/EmulatorOptions.schema.json
+++ b/inst/schema/EmulatorOptions.schema.json
@@ -31,7 +31,7 @@
     "irs_future": { "type": "number", "minimum": 0, "maximum": 100 },
     "lsm": { "type": "number", "minimum": 0, "maximum": 100 }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "is_seasonal",
     "current_malaria_prevalence",

--- a/inst/schema/EmulatorOptions.schema.json
+++ b/inst/schema/EmulatorOptions.schema.json
@@ -3,7 +3,6 @@
   "title": "EmulatorOptions",
   "type": "object",
   "properties": {
-    "triggerRun": { "type": "boolean" },
     "population": { "type": "integer", "minimum": 0 },
     "is_seasonal": { "type": "boolean" },
     "current_malaria_prevalence": {
@@ -22,9 +21,6 @@
     "py_pbo": { "type": "number", "minimum": 0, "maximum": 100 },
     "py_pyrrole": { "type": "number", "minimum": 0, "maximum": 100 },
     "py_ppf": { "type": "number", "minimum": 0, "maximum": 100 },
-    "itn_total": {
-      "type": "null"
-    },
     "irs_coverage": { "type": "number", "minimum": 0, "maximum": 100 },
     "itn_future": { "type": "number", "minimum": 0, "maximum": 100 },
     "itn_future_types": {
@@ -34,22 +30,10 @@
     },
     "routine_coverage": { "type": "boolean" },
     "irs_future": { "type": "number", "minimum": 0, "maximum": 100 },
-    "lsm": { "type": "number", "minimum": 0, "maximum": 100 },
-    "people_per_bednet": { "type": "number", "minimum": 0 },
-    "people_per_household": { "type": "integer", "minimum": 1 },
-    "procurement_buffer": { "type": "integer", "minimum": 0 },
-    "py_only_cost": { "type": "number", "minimum": 0 },
-    "py_pbo_cost": { "type": "number", "minimum": 0 },
-    "py_pyrrole_cost": { "type": "number", "minimum": 0 },
-    "py_ppf_cost": { "type": "number", "minimum": 0 },
-    "mass_distribution_cost": { "type": "number", "minimum": 0 },
-    "continuous_itn_distribution_cost": { "type": "number", "minimum": 0 },
-    "irs_household_annual_cost": { "type": "number", "minimum": 0 },
-    "lsm_cost": { "type": "number", "minimum": 0 }
+    "lsm": { "type": "number", "minimum": 0, "maximum": 100 }
   },
   "additionalProperties": false,
   "required": [
-    "triggerRun",
     "population",
     "is_seasonal",
     "current_malaria_prevalence",
@@ -60,23 +44,11 @@
     "py_pbo",
     "py_pyrrole",
     "py_ppf",
-    "itn_total",
     "irs_coverage",
     "itn_future",
     "itn_future_types",
     "routine_coverage",
     "irs_future",
-    "lsm",
-    "people_per_bednet",
-    "people_per_household",
-    "procurement_buffer",
-    "py_only_cost",
-    "py_pbo_cost",
-    "py_pyrrole_cost",
-    "py_ppf_cost",
-    "mass_distribution_cost",
-    "continuous_itn_distribution_cost",
-    "irs_household_annual_cost",
-    "lsm_cost"
+    "lsm"
   ]
 }

--- a/inst/schema/EmulatorResults.schema.json
+++ b/inst/schema/EmulatorResults.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object"
+}

--- a/inst/schema/EmulatorResults.schema.json
+++ b/inst/schema/EmulatorResults.schema.json
@@ -1,4 +1,32 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object"
+  "type": "object",
+  "properties": {
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "scenario": { "type": "string" },
+          "year": { "type": "integer" },
+          "cases_per_1000": { "type": "number" }
+        },
+        "required": ["scenario", "year", "cases_per_1000"],
+        "additionalProperties": false
+      }
+    },
+    "prevalence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "scenario": { "type": "string" },
+          "days": { "type": "integer" },
+          "prevalence": { "type": "number" }
+        },
+        "required": ["scenario", "days", "prevalence"],
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/inst/schema/EmulatorResults.schema.json
+++ b/inst/schema/EmulatorResults.schema.json
@@ -9,9 +9,9 @@
         "properties": {
           "scenario": { "type": "string" },
           "year": { "type": "integer" },
-          "cases_per_1000": { "type": "number" }
+          "casesPer1000": { "type": "number" }
         },
-        "required": ["scenario", "year", "cases_per_1000"],
+        "required": ["scenario", "year", "casesPer1000"],
         "additionalProperties": false
       }
     },

--- a/inst/schema/EmulatorResults.schema.json
+++ b/inst/schema/EmulatorResults.schema.json
@@ -1,32 +1,4 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-    "cases": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "scenario": { "type": "string" },
-          "year": { "type": "integer" },
-          "cases_per_1000": { "type": "number" }
-        },
-        "required": ["scenario", "year", "cases_per_1000"],
-        "additionalProperties": false
-      }
-    },
-    "prevalence": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "scenario": { "type": "string" },
-          "days": { "type": "integer" },
-          "prevalence": { "type": "number" }
-        },
-        "required": ["scenario", "days", "prevalence"],
-        "additionalProperties": false
-      }
-    }
-  }
+  "type": "object"
 }

--- a/inst/schema/FormOptions.schema.json
+++ b/inst/schema/FormOptions.schema.json
@@ -30,7 +30,7 @@
         "description": { "type": "string" },
         "helpText": { "type": "string" },
         "collapsible": { "type": "boolean" },
-        "triggersRerun": { "type": "boolean" },
+        "triggersRun": { "type": "boolean" },
         "preRun": { "type": "boolean" },
         "subGroups": {
           "type": "array",

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -401,7 +401,7 @@ test_that("runs emulator and returns cases and prevalence", {
   body <- jsonlite::fromJSON(res_api$body)
   expect_equal(body$status, "success")
   expect_setequal(names(body$data), c("cases", "prevalence"))
-  expect_true(all(body$data$cases$cases_per_1000 > 0))
+  expect_true(all(body$data$cases$casesPer1000 > 0))
   expect_true(all(body$data$prevalence$prevalence > 0))
 })
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -401,6 +401,8 @@ test_that("runs emulator and returns cases and prevalence", {
   body <- jsonlite::fromJSON(res_api$body)
   expect_equal(body$status, "success")
   expect_setequal(names(body$data), c("cases", "prevalence"))
+  expect_true(all(body$data$cases$cases_per_1000 > 0))
+  expect_true(all(body$data$prevalence$prevalence > 0))
 })
 
 # TODO: delete old emulator tests

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -372,6 +372,39 @@ test_that("strategise", {
   expect_equal(res_api$body, res_endpoint$body)
 })
 
+test_that("runs emulator and returns cases and prevalence", {
+  form_options <- jsonlite::toJSON(list(
+        pyrethroid_resistance = 50,
+        py_only = 30,
+        py_pbo = 20,
+        py_pyrrole = 10,
+        py_ppf = 5,
+        current_malaria_prevalence = 15,
+        preference_for_biting = 25,
+        preference_for_biting_in_bed = 35,
+        is_seasonal = TRUE,
+        irs_coverage = 40,
+        # interventions
+        itn_future = 45,
+        itn_future_types = c("py_only", "py_pbo"),
+        irs_future = 50,
+        routine_coverage = TRUE,
+        lsm = 60
+    ), auto_unbox = TRUE)
+
+  db <- mintr_test_db()
+  api <- api_build(db)
+
+  res_api <- api$request("POST", "/emulator/run", body = form_options)
+  expect_equal(res_api$status, 200)
+  
+  # TODO: check correct results
+  body <- jsonlite::fromJSON(res_api$body)
+  expect_equal(body$status, "success")
+  expect_named(body$data, c("cases", "prevalence"))  
+})
+
+# TODO: delete old emulator tests
 test_that("emulator is optional", {
   db <- mintr_test_db()
   api <- api_build(db, emulator_root=NULL)

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -398,7 +398,6 @@ test_that("runs emulator and returns cases and prevalence", {
   res_api <- api$request("POST", "/emulator/run", body = form_options)
   expect_equal(res_api$status, 200)
   
-  # TODO: check correct results
   body <- jsonlite::fromJSON(res_api$body)
   expect_equal(body$status, "success")
   expect_setequal(names(body$data), c("cases", "prevalence"))

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -1,6 +1,6 @@
 
 # Test data setup
-create_test_options <- function() {
+create_test_form_options <- function() {
     list(
         pyrethroid_resistance = 50,
         py_only = 30,
@@ -22,7 +22,7 @@ create_test_options <- function() {
 }
 
 test_that("transform_options correctly transforms form options", {
-    options <- create_test_options()
+    options <- create_test_form_options()
     result <- transform_options(options)
     
     # Test percentage conversions
@@ -48,7 +48,7 @@ test_that("transform_options correctly transforms form options", {
 })
 
 test_that("transform_options handles FALSE boolean values", {
-    options <- create_test_options()
+    options <- create_test_form_options()
     options$is_seasonal <- FALSE
     options$routine_coverage <- FALSE
     
@@ -207,7 +207,7 @@ test_that("build_minter_params handles complex scenario combinations", {
         res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
         py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
         season = 1L, irs = 0.4, itn_future = 0.45,
-        net_type_future = c("py_only", "py_pbo"), irs_future = 0.6, 
+        net_type_future = c("py_only", "py_pbo", "py_pyrrole", "py_ppf"), irs_future = 0.6, 
         routine = 1L, lsm = 0.3
     )
     
@@ -215,7 +215,9 @@ test_that("build_minter_params handles complex scenario combinations", {
     
     expected_tags <- c("no_intervention", "irs_only", "lsm_only", 
                        "py_only_only", "py_only_with_lsm",
-                       "py_pbo_only", "py_pbo_with_lsm")
+                       "py_pbo_only", "py_pbo_with_lsm",
+                       "py_pyrrole_only", "py_pyrrole_with_lsm",
+                       "py_ppf_only", "py_ppf_with_lsm")
     expect_equal(result$scenario_tag, expected_tags)
-    expect_equal(length(result$scenario_tag), 7)
+    expect_equal(length(result$scenario_tag), 11)
 })

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -1,0 +1,221 @@
+
+# Test data setup
+create_test_options <- function() {
+    list(
+        pyrethroid_resistance = 50,
+        py_only = 30,
+        py_pbo = 20,
+        py_pyrrole = 10,
+        py_ppf = 5,
+        current_malaria_prevalence = 15,
+        preference_for_biting = 25,
+        preference_for_biting_in_bed = 35,
+        is_seasonal = TRUE,
+        irs_coverage = 40,
+        # interventions
+        itn_future = 45,
+        itn_future_types = c("py_only", "py_pbo"),
+        irs_future = 50,
+        routine_coverage = TRUE,
+        lsm = 60
+    )
+}
+
+test_that("transform_options correctly transforms form options", {
+    options <- create_test_options()
+    result <- transform_options(options)
+    
+    # Test percentage conversions
+    expect_equal(result$res_use, 0.5)
+    expect_equal(result$py_only, 0.3)
+    expect_equal(result$py_pbo, 0.2)
+    expect_equal(result$py_pyrrole, 0.1)
+    expect_equal(result$py_ppf, 0.05)
+    expect_equal(result$prev, 0.15)
+    expect_equal(result$Q0, 0.25)
+    expect_equal(result$phi, 0.35)
+    expect_equal(result$irs, 0.4)
+    expect_equal(result$itn_future, 0.45)
+    expect_equal(result$irs_future, 0.5)
+    expect_equal(result$lsm, 0.6)
+    
+    # Test type conversions
+    expect_equal(result$season, 1L)
+    expect_equal(result$routine, 1L)
+    
+    # Test direct assignments
+    expect_equal(result$net_type_future, c("py_only", "py_pbo"))
+})
+
+test_that("transform_options handles FALSE boolean values", {
+    options <- create_test_options()
+    options$is_seasonal <- FALSE
+    options$routine_coverage <- FALSE
+    
+    result <- transform_options(options)
+    
+    expect_equal(result$season, 0L)
+    expect_equal(result$routine, 0L)
+})
+
+test_that("create_base_scenario creates correct baseline scenario", {
+    transformed_options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = c("py_only", "py_pbo"), irs_future = 0.5,
+        routine = 1L, lsm = 0.6
+    )
+    
+    result <- create_base_scenario(transformed_options)
+    
+    expect_equal(result$scenario_tag, "no_intervention")
+    expect_equal(result$res_use, 0.5)
+    expect_equal(result$py_only, 0.3)
+    expect_equal(result$prev, 0.15)
+    expect_equal(result$irs, 0.4)
+    
+    # Check interventions are set to zero/NA
+    expect_equal(result$itn_future, 0)
+    expect_true(is.na(result$net_type_future))
+    expect_equal(result$irs_future, 0)
+    expect_equal(result$routine, 0)
+    expect_equal(result$lsm, 0)
+})
+
+
+test_that("with_overrides correctly updates scenario fields", {
+    base_scenario <- list(
+        scenario_tag = "base",
+        field1 = 10,
+        field2 = "original",
+        field3 = TRUE
+    )
+    
+    overrides <- list(
+        scenario_tag = "updated",
+        field2 = "modified",
+        field4 = 42
+    )
+    
+    result <- with_overrides(base_scenario, overrides)
+    
+    expect_equal(result$scenario_tag, "updated")
+    expect_equal(result$field1, 10)  # unchanged
+    expect_equal(result$field2, "modified")
+    expect_equal(result$field3, TRUE)  # unchanged
+    expect_equal(result$field4, 42)  # new field
+})
+
+test_that("append_scenario correctly concatenates scenarios column-wise", {
+    accumulator <- list(
+        field1 = c(1, 2),
+        field2 = c("a", "b"),
+        field3 = c(TRUE, FALSE)
+    )
+    
+    new_scenario <- list(
+        field1 = 3,
+        field2 = "c",
+        field3 = TRUE
+    )
+    
+    result <- append_scenario(accumulator, new_scenario)
+    
+    expect_equal(result$field1, c(1, 2, 3))
+    expect_equal(result$field2, c("a", "b", "c"))
+    expect_equal(result$field3, c(TRUE, FALSE, TRUE))
+})
+
+test_that("build_minter_params creates baseline scenario only when no interventions", {
+    options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = character(0), irs_future = 0, routine = 0L, lsm = 0
+    )
+    
+    result <- build_minter_params(options)
+    
+    expect_equal(result$scenario_tag, "no_intervention")
+    expect_equal(length(result$scenario_tag), 1)
+})
+
+test_that("build_minter_params adds IRS scenario when irs_future > 0", {
+    options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = character(0), irs_future = 0.6, routine = 0L, lsm = 0
+    )
+    
+    result <- build_minter_params(options)
+    
+    expect_equal(result$scenario_tag, c("no_intervention", "irs_only"))
+    expect_equal(result$irs_future, c(0, 0.6))
+})
+
+test_that("build_minter_params adds LSM scenario when lsm > 0", {
+    options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = character(0), irs_future = 0, routine = 0L, lsm = 0.3
+    )
+    
+    result <- build_minter_params(options)
+    
+    expect_equal(result$scenario_tag, c("no_intervention", "lsm_only"))
+    expect_equal(result$lsm, c(0, 0.3))
+})
+
+test_that("build_minter_params adds net type scenarios", {
+    options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = c("py_only", "py_pbo"), irs_future = 0, 
+        routine = 1L, lsm = 0
+    )
+    
+    result <- build_minter_params(options)
+    
+    expected_tags <- c("no_intervention", "py_only_only", "py_pbo_only")
+    expect_equal(result$scenario_tag, expected_tags)
+    expect_equal(result$net_type_future, c(NA_character_, "py_only", "py_pbo"))
+    expect_equal(result$itn_future, c(0, 0.45, 0.45))
+})
+
+test_that("build_minter_params adds net type with LSM scenarios", {
+    options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = c("py_only"), irs_future = 0, 
+        routine = 1L, lsm = 0.3
+    )
+    
+    result <- build_minter_params(options)
+    
+    expected_tags <- c("no_intervention", "lsm_only", "py_only_only", "py_only_with_lsm")
+    expect_equal(result$scenario_tag, expected_tags)
+    expect_equal(result$lsm, c(0, 0.3, 0, 0.3))
+})
+
+test_that("build_minter_params handles complex scenario combinations", {
+    options <- list(
+        res_use = 0.5, py_only = 0.3, py_pbo = 0.2, py_pyrrole = 0.1,
+        py_ppf = 0.05, prev = 0.15, Q0 = 0.25, phi = 0.35,
+        season = 1L, irs = 0.4, itn_future = 0.45,
+        net_type_future = c("py_only", "py_pbo"), irs_future = 0.6, 
+        routine = 1L, lsm = 0.3
+    )
+    
+    result <- build_minter_params(options)
+    
+    expected_tags <- c("no_intervention", "irs_only", "lsm_only", 
+                       "py_only_only", "py_only_with_lsm",
+                       "py_pbo_only", "py_pbo_with_lsm")
+    expect_equal(result$scenario_tag, expected_tags)
+    expect_equal(length(result$scenario_tag), 7)
+})

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -31,7 +31,7 @@ test_that("run_emulator returns expected results", {
     
     # cases checks
     expect_true(all(c("scenario", "year", "cases_per_1000") %in% colnames(cases)))
-    year_count <- cases |> dplyr::group_by(scenario) |> dplyr::summarise(n_years = n_distinct(year))
+    year_count <- cases |> dplyr::summarise(n_years = n_distinct(year), .by = scenario)
     expect_true(all(year_count$n_years == 4)) # 4 years
     expect_setequal(expected_scenarios, year_count$scenario)
     # prevalence checks
@@ -40,7 +40,6 @@ test_that("run_emulator returns expected results", {
     weeks_in_4_years <- round(365 * 4 / 7)
     expect_true(all(row_count$n == weeks_in_4_years)) 
     expect_setequal(expected_scenarios, row_count$scenario)
-
 })
 
 test_that("transform_options correctly transforms form options", {

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -30,7 +30,7 @@ test_that("run_emulator returns expected results", {
     prevalence <- result$prevalence
     
     # cases checks
-    expect_true(all(c("scenario", "year", "cases_per_1000") %in% colnames(cases)))
+    expect_true(all(c("scenario", "year", "casesPer1000") %in% colnames(cases)))
     year_count <- cases |> dplyr::summarise(n_years = n_distinct(year), .by = scenario)
     expect_true(all(year_count$n_years == 4)) # 4 years
     expect_setequal(expected_scenarios, year_count$scenario)

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -20,6 +20,28 @@ create_test_form_options <- function() {
         lsm = 60
     )
 }
+test_that("run_emulator returns expected results", {
+    expected_scenarios <- c("irs_only", "lsm_only", "no_intervention", "py_only_only", "py_only_with_lsm", "py_pbo_only", "py_pbo_with_lsm")
+    options <- create_test_form_options()
+
+    result <- run_emulator(options)
+
+    cases <- result$cases
+    prevalence <- result$prevalence
+    
+    # cases checks
+    expect_true(all(c("scenario", "year", "cases_per_1000") %in% colnames(cases)))
+    year_count <- cases |> dplyr::group_by(scenario) |> dplyr::summarise(n_years = n_distinct(year))
+    expect_true(all(year_count$n_years == 4)) # 4 years
+    expect_setequal(expected_scenarios, year_count$scenario)
+    # prevalence checks
+    expect_true(all(c("scenario", "days", "prevalence") %in% colnames(prevalence)))
+    row_count <- prevalence |> dplyr::group_by(scenario) |> count()
+    weeks_in_4_years <- round(365 * 4 / 7)
+    expect_true(all(row_count$n == weeks_in_4_years)) 
+    expect_setequal(expected_scenarios, row_count$scenario)
+
+})
 
 test_that("transform_options correctly transforms form options", {
     options <- create_test_form_options()


### PR DESCRIPTION
The following PR is responsible for running the emulator. The input is form options from the Svelte app and then the emulator will run several times depending on combinations of form options passed up to a maximum of 11 ((no intervention, Pyrethroid-only ITN, Pyrethroid-PBO ITN, Pyrethroid-pyrrole ITN, Pyrethroid-pyriproxyfen , IRS ONLY, LSM ONLY, Pyrethroid-only ITN + LSM, Pyrethroid-PBO ITN + LSM, Pyrethroid-pyrrole ITN + LSM, Pyrethroid-pyriproxyfen + LSM)

Testing:
I have setup [mint-v2](https://github.com/mrc-ide/mint-v2/pull/4) with this branch. The best way to test is to play with the form values there and see the cases and prevelance timeseries get shown.