### PR TITLE
Make changes to reflect MINTer changes

### DIFF
--- a/R/emulator.R
+++ b/R/emulator.R
@@ -2,7 +2,7 @@ run_emulator <- function(options) {
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 
-    results <- do.call(MINTer::run_minter_scenarios, minter_params)
+    results <- do.call(MINTer::run_mintweb_controller, minter_params)
 
     post_process_results(results)
 }

--- a/R/emulator.R
+++ b/R/emulator.R
@@ -2,7 +2,7 @@ run_emulator <- function(options) {
     transformed_options <- transform_options(options)
     minter_params <- build_minter_params(transformed_options)
 
-    results <- do.call(MINTer::run_mint_scenarios, minter_params)
+    results <- do.call(MINTer::run_minter_scenarios, minter_params)
 
     post_process_results(results)
 }
@@ -122,11 +122,11 @@ build_minter_params <- function(options) {
 }
 
 post_process_results <- function(results) {
-    # prevalence time steps are weekly
-    days_in_week <- 7
+    # prevalence time steps are fortnightly
+    days_in_fortnight <- 14
     days_in_year <- 365
     results$prevalence <- results$prevalence |>
-        dplyr::mutate(days = row_number() * days_in_week, .by = scenario)
+        dplyr::mutate(days = row_number() * days_in_fortnight, .by = scenario)
     results$cases <- results$cases |> rename(casesPer1000 = cases_per_1000) |>
         dplyr::mutate(
             year = row_number(),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN install_packages \
         tidyr
 
 RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk", "CosmoNaught/MINTer"))'
-RUN Rscript -e 'MINTer::initialize_python()'
+RUN Rscript -e 'MINTer::preload_all_models()'
 
 WORKDIR /mintr
 

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -37,8 +37,8 @@ test_that("run_emulator returns expected results", {
     # prevalence checks
     expect_true(all(c("scenario", "days", "prevalence") %in% colnames(prevalence)))
     row_count <- prevalence |> dplyr::group_by(scenario) |> count()
-    weeks_in_4_years <- round(365 * 4 / 7)
-    expect_true(all(row_count$n == weeks_in_4_years)) 
+    fortnights_in_4_years <- ceiling(365 * 4 / 14)
+    expect_true(all(row_count$n == fortnights_in_4_years)) 
     expect_setequal(expected_scenarios, row_count$scenario)
 })
 


### PR DESCRIPTION
This PR makes changes to adjust for fixes in MINTer.  The following is done:
- Fixed speed issues by preloading models into memory
- fixed timeries for prevalence. This is now fortnightly data

Testing:
run with [mint-v2](https://github.com/mrc-ide/mint-v2). change `common.sh` replace `main` with `minter-slowness-fix`. Then create region and run model. Adjust sliders and see its faster now and still works