### PR TITLE
Mrc-6747 Load models on load

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -16,8 +16,13 @@ main <- function(args = commandArgs(TRUE)) {
   port <- opts$port
   message("Compiling docs")
   docs <- get_compiled_docs()
+
   message("Opening database")
   db <- mintr_db_open(opts$data, docs)
+  
+  message("Loading emulator models")
+  MINTer::preload_all_models()
+  
   message("Starting API")
   api_run(port, db, opts$emulator_root)
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,6 @@ RUN install_packages \
         tidyr
 
 RUN Rscript -e 'remotes::install_github(c("r-opt/ROIoptimizer", "r-opt/rmpk", "CosmoNaught/MINTer"))'
-RUN Rscript -e 'MINTer::preload_all_models()'
 
 WORKDIR /mintr
 

--- a/tests/testthat/test-emulator.R
+++ b/tests/testthat/test-emulator.R
@@ -13,7 +13,7 @@ create_test_form_options <- function() {
         is_seasonal = TRUE,
         irs_coverage = 40,
         # interventions
-        itn_future = 0,
+        itn_future = 45,
         itn_future_types = c("py_only", "py_pbo"),
         irs_future = 50,
         routine_coverage = TRUE,


### PR DESCRIPTION
Have moved preloading of models from image to startup on container. This is because it needs to be initialized in the R sessions

Testing:
Run mint-v2 `run_dependencies` and change API_VERSION in common to this branch `mrc-6747-model-loads`. and view logs and see models getting loaded on initial run of container