### PR TITLE
Mrc-6645 Strategise updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     ROIoptimizer,
     ROI.plugin.glpk,
     tidyr,
+    purrr,
     MINTer
 Suggests:
     fs,

--- a/R/api.R
+++ b/R/api.R
@@ -19,7 +19,7 @@ api_build <- function(db, emulator_root=NULL) {
   pr$handle(endpoint_graph_cases_averted_config())
   pr$handle(endpoint_impact_intepretation(db))
   pr$handle(endpoint_cost_intepretation(db))
-  pr$handle(endpoint_strategise(db))
+  pr$handle(endpoint_strategise())
   pr$handle(endpoint_version())
   pr$handle(endpoint_emulator_run())
   if (!is.null(emulator_root)) {
@@ -239,22 +239,19 @@ target_cost_interpretation <- function(db) {
   }
 }
 
-endpoint_strategise <- function(db) {
+endpoint_strategise <- function() {
   porcelain::porcelain_endpoint$new(
     "POST", "/strategise",
-    target_strategise(db),
+    target_strategise,
     porcelain::porcelain_input_body_json("json", "StrategiseOptions"),
     returning = porcelain::porcelain_returning_json("Strategise"))
 }
 
-target_strategise <- function(db) {
-  force(db)
-  function(json) {
-    jsonlite::toJSON(
-      strategise(jsonlite::fromJSON(json, simplifyVector=FALSE), db),
-      auto_unbox=TRUE
-    )
-  }
+target_strategise <- function(json) {
+  jsonlite::toJSON(
+    strategise(jsonlite::fromJSON(json, simplifyVector=TRUE, flatten=TRUE)),
+    auto_unbox=TRUE
+  )
 }
 
 endpoint_emulator_run <- function() {

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -3,7 +3,7 @@
 do_optimise <- function(data, budget) {
   # rmpk requires an equal number of scenarios for each region, so we add missing
   # combinations ensuring that they are less attractive than no intervention
-  data <- complete(data, region, intervention, fill = list(cost = max(data$cost), casesAverted = -.Machine$double.xmax))
+  data <- complete(data, region, intervention, fill = list(cost = max(data$cost), casesAverted = -.Machine$integer.max))
   region <- intervention <- cost <- casesAverted <- i <- j <- NULL # used by dplyr
   cost_df <- distinct(data, region, intervention, cost) %>%
     group_by(intervention) %>%

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -3,7 +3,7 @@
 do_optimise <- function(data, budget) {
   # rmpk requires an equal number of scenarios for each region, so we add missing
   # combinations ensuring that they are less attractive than no intervention
-  data <- complete(data, region, intervention, fill = list(cost = max(data$cost), casesAverted = 0))
+  data <- complete(data, region, intervention, fill = list(cost = max(data$cost), casesAverted = -.Machine$double.xmax))
   region <- intervention <- cost <- casesAverted <- i <- j <- NULL # used by dplyr
   cost_df <- distinct(data, region, intervention, cost) %>%
     group_by(intervention) %>%

--- a/R/optimise.R
+++ b/R/optimise.R
@@ -1,51 +1,51 @@
 #' @import tidyr
 #' @import dplyr
 do_optimise <- function(data, budget) {
-  # rmpk requires an equal number of scenarios for each zone, so we add missing
+  # rmpk requires an equal number of scenarios for each region, so we add missing
   # combinations ensuring that they are less attractive than no intervention
-  data <- complete(data, zone, intervention, fill = list(cost = max(data$cost), cases_averted = 0))
-  zone <- intervention <- cost <- cases_averted <- i <- j <- NULL # used by dplyr
-  cost_df <- distinct(data, zone, intervention, cost) %>%
+  data <- complete(data, region, intervention, fill = list(cost = max(data$cost), casesAverted = 0))
+  region <- intervention <- cost <- casesAverted <- i <- j <- NULL # used by dplyr
+  cost_df <- distinct(data, region, intervention, cost) %>%
     group_by(intervention) %>%
     mutate(j = cur_group_id()) %>%
-    group_by(zone) %>%
+    group_by(region) %>%
     mutate(i = cur_group_id()) %>%
     ungroup()
-  cases_av_df <- distinct(data, zone, intervention, cases_averted) %>%
+  cases_av_df <- distinct(data, region, intervention, casesAverted) %>%
     group_by(intervention) %>%
     mutate(j = cur_group_id()) %>%
-    group_by(zone) %>%
+    group_by(region) %>%
     mutate(i = cur_group_id()) %>%
     ungroup()
-  cost <- function(zone, intervention) {
-    filter(cost_df, i == !!zone, j == !!intervention)$cost
+  cost <- function(region, intervention) {
+    filter(cost_df, i == !!region, j == !!intervention)$cost
   }
-  cases_av <- function(zone, intervention) {
-    filter(cases_av_df, i == !!zone, j == !!intervention)$cases_averted
+  cases_av <- function(region, intervention) {
+    filter(cases_av_df, i == !!region, j == !!intervention)$casesAverted
   }
-  n_zones <- n_distinct(data$zone)
+  n_regions <- n_distinct(data$region)
   n_interventions <- n_distinct(data$intervention)
 
   ##' @import ROI.plugin.glpk
   optimise <- function(budget) {
     value <- NULL # used by dplyr
     model <- rmpk::optimization_model(rmpk::ROI_optimizer("glpk"))
-    y <- model$add_variable("y", i = 1:n_zones, j = 1:n_interventions, type = "integer", lb = 0, ub = 1)
-    model$set_objective(rmpk::sum_expr(y[i, j] * cases_av(i, j), i = 1:n_zones, j = 1:n_interventions), sense = "max")
+    y <- model$add_variable("y", i = 1:n_regions, j = 1:n_interventions, type = "integer", lb = 0, ub = 1)
+    model$set_objective(rmpk::sum_expr(y[i, j] * cases_av(i, j), i = 1:n_regions, j = 1:n_interventions), sense = "max")
     # rmpk currently fails if all scenarios have zero cost. work around this by
     # only constraining costs if some non-zero cost scenarios are provided.
     if (n_interventions > 1) {
-      model$add_constraint(rmpk::sum_expr(y[i, j] * cost(i, j), i = 1:n_zones, j = 1:n_interventions) <= budget)
+      model$add_constraint(rmpk::sum_expr(y[i, j] * cost(i, j), i = 1:n_regions, j = 1:n_interventions) <= budget)
     }
-    model$add_constraint(rmpk::sum_expr(y[i, j], j = 1:n_interventions) == 1, i = 1:n_zones)
+    model$add_constraint(rmpk::sum_expr(y[i, j], j = 1:n_interventions) == 1, i = 1:n_regions)
     model$optimize()
     model$get_variable_value(y[i, j]) %>%
       filter(value == 1) %>%
       left_join(cost_df, c("i", "j")) %>%
-      left_join(select(cases_av_df, cases_averted, i, j), by = c("i", "j"))
+      left_join(select(cases_av_df, casesAverted, i, j), by = c("i", "j"))
   }
 
   optimise(budget) %>%
-    select(zone, intervention, cost, cases_averted) %>%
-    arrange(zone)
+    select(region, intervention, cost, casesAverted) %>%
+    arrange(region)
 }

--- a/R/strategise.R
+++ b/R/strategise.R
@@ -1,91 +1,32 @@
-get_cost <- function(baseline_settings, intervention_settings, intervention) {
-  population <- baseline_settings$population
-  procurement_buffer <- (intervention_settings$procureBuffer + 100) / 100
-  cost_per_net_llin <- intervention_settings$priceNetStandard
-  cost_per_net_pbo <- intervention_settings$priceNetPBO
-  cost_per_net_pyrrole <- intervention_settings$priceNetPyrrole
-  cost_delivery_per_net <- intervention_settings$priceDelivery
-  people_per_net <- intervention_settings$procurePeoplePerNet
-  cost_irs_per_person <- intervention_settings$priceIRSPerPerson
-  switch(
-    intervention,
-    "none" = 0,
-    "llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer),
-    "llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer),
-    "pyrrole-pbo" = (cost_delivery_per_net + cost_per_net_pyrrole) * (population / people_per_net * procurement_buffer),
-    "irs" = 3 * cost_irs_per_person * population,
-    "irs-llin" = (cost_delivery_per_net + cost_per_net_llin) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population,
-    "irs-llin-pbo" = (cost_delivery_per_net + cost_per_net_pbo) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population,
-    "irs-pyrrole-pbo" = (cost_delivery_per_net + cost_per_net_pyrrole) * (population / people_per_net * procurement_buffer) + 3 * cost_irs_per_person * population
-  )
-}
+strategise <- function(options) {
+  combined_region_data <- combine_region_data(options$regions)
+  cost_thresholds <- c(1, 0.95, 0.9, 0.85, 0.8)
+  
+  lapply(cost_thresholds, function(threshold) {
+    budget <- options$budget * threshold
+    interventions <- do_optimise(combined_region_data, budget)
 
-get_intervention_data <- function(baseline_settings, intervention_settings, db) {
-  table <- db$get_table(baseline_settings)
-  rows <- table$intervention == "none"
-  if (intervention_settings$netUse != "0") {
-    rows <- rows | (
-      table$intervention %in% c("llin", "llin-pbo", "pyrrole-pbo") &
-      table$netUse == intervention_settings$netUse &
-      table$irsUse == "n/a"
-    )
-  }
-  if (intervention_settings$irsUse != "0") {
-    rows <- rows | (
-      table$intervention == "irs" &
-      table$netUse == "n/a" &
-      table$irsUse == intervention_settings$irsUse
-    )
-  }
-  if (intervention_settings$netUse != "0"
-    && intervention_settings$irsUse != "0") {
-    rows <- rows | (
-      table$intervention %in% c("irs-llin", "irs-llin-pbo", "irs-pyrrole-pbo") &
-      table$netUse == intervention_settings$netUse &
-      table$irsUse == intervention_settings$irsUse
-    )
-  }
-  table <- table[rows, c("intervention", "casesAverted", "casesAvertedErrorMinus", "casesAvertedErrorPlus")]
-  colnames(table) <- c("intervention", "cases_averted", "cases_averted_error_minus", "cases_averted_error_plus")
-  # costs are calculated across 3 years in `get_cost` so do the same for cases averted here
-  table$cases_averted <- table$cases_averted * 3
-  table$cases_averted_error_minus <- table$cases_averted_error_minus * 3
-  table$cases_averted_error_plus <- table$cases_averted_error_plus * 3
-  table
-}
-
-get_cost_data <- function(baseline_settings, intervention_settings, interventions) {
-  costs <- lapply(interventions, function(intervention) {
-    cost <- get_cost(baseline_settings, intervention_settings, intervention)
-    list(intervention = intervention, cost = cost)
-  })
-  do.call(rbind.data.frame, costs)
-}
-
-strategise <- function(options, db) {
-  data <- lapply(options$zones, function(zone) {
-    data <- get_intervention_data(zone$baselineSettings,
-                                  zone$interventionSettings, db)
-    cost <- get_cost_data(zone$baselineSettings, zone$interventionSettings,
-                      unique(data$intervention))
-    data <- merge(data, cost, by = "intervention", sort = FALSE)
-    data$zone <- zone$name
-    data
-  })
-  data <- do.call(rbind, data)
-  # The optimiser doesn't preserve extraneous columns so we save them here
-  # and merge them back into its output
-  errors <- data[c("zone", "intervention", "cases_averted_error_minus", "cases_averted_error_plus")]
-  lapply(c(1, 0.95, 0.9, 0.85, 0.8), function(cost_threshold) {
-    budget <- options$budget * cost_threshold
-    res <- do_optimise(data, budget)
-    res <- merge(res, errors, by = c("zone", "intervention"), sort = FALSE)
-    names(res)[names(res) == "cases_averted"] <- "casesAverted"
-    names(res)[names(res) == "cases_averted_error_minus"] <- "casesAvertedErrorMinus"
-    names(res)[names(res) == "cases_averted_error_plus"] <- "casesAvertedErrorPlus"
     list(
-      costThreshold = cost_threshold,
-      interventions = res[c("zone", "intervention", "cost", "casesAverted", "casesAvertedErrorMinus", "casesAvertedErrorPlus")]
+      costThreshold = threshold,
+      interventions = interventions
     )
   })
+}
+
+combine_region_data <- function(regions_df) {  
+  regions_df |>
+    # add no_intervention to each region's interventions
+    dplyr::mutate(
+      interventions = purrr::map(interventions, add_no_intervention)
+    ) |>
+    tidyr::unnest(interventions)
+}
+
+add_no_intervention <- function(interventions_df) {
+  no_intervention <- data.frame(
+    intervention = "no_intervention", 
+    cost = 0, 
+    casesAverted = 0
+  )
+  dplyr::bind_rows(interventions_df, no_intervention)
 }

--- a/R/strategise.R
+++ b/R/strategise.R
@@ -1,5 +1,5 @@
 strategise <- function(options) {
-  combined_region_data <- combine_region_data(options$regions)
+  combined_region_data <- unnest_region_data(options$regions)
   cost_thresholds <- c(1, 0.95, 0.9, 0.85, 0.8)
   
   lapply(cost_thresholds, function(threshold) {
@@ -13,7 +13,7 @@ strategise <- function(options) {
   })
 }
 
-combine_region_data <- function(regions_df) {  
+unnest_region_data <- function(regions_df) {  
   regions_df |>
     # add no_intervention to each region's interventions
     dplyr::mutate(

--- a/inst/schema/Strategise.schema.json
+++ b/inst/schema/Strategise.schema.json
@@ -14,7 +14,7 @@
             {
               "type": "object",
               "properties": {
-                "zone": {
+                "region": {
                   "type": "string"
                 },
                 "intervention": {
@@ -25,32 +25,16 @@
                 },
                 "casesAverted": {
                   "type": "number"
-                },
-                "casesAvertedErrorMinus": {
-                  "type": "number"
-                },
-                "casesAvertedErrorPlus": {
-                  "type": "number"
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "zone",
-                "intervention",
-                "cost",
-                "casesAverted",
-                "casesAvertedErrorMinus",
-                "casesAvertedErrorPlus"
-              ]
+              "required": ["region", "intervention", "cost", "casesAverted"]
             }
           ]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "costThreshold",
-        "interventions"
-      ]
+      "required": ["costThreshold", "interventions"]
     }
   ]
 }

--- a/inst/schema/StrategiseOptions.schema.json
+++ b/inst/schema/StrategiseOptions.schema.json
@@ -5,107 +5,41 @@
     "budget": {
       "type": "number"
     },
-    "zones": {
+    "regions": {
       "type": "array",
       "minItems": 1,
-      "items": [
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "baselineSettings": {
+      "items": {
+        "type": "object",
+        "properties": {
+          "region": {
+            "type": "string"
+          },
+          "interventions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
               "type": "object",
               "properties": {
-                "population": {
-                  "type": "integer"
-                },
-                "seasonalityOfTransmission": {
+                "intervention": {
                   "type": "string"
                 },
-                "currentPrevalence": {
-                  "type": "string"
+                "cost": {
+                  "type": "number"
                 },
-                "bitingIndoors": {
-                  "type": "string"
-                },
-                "bitingPeople": {
-                  "type": "string"
-                },
-                "levelOfResistance": {
-                  "type": "string"
-                },
-                "itnUsage": {
-                  "type": "string"
-                },
-                "sprayInput": {
-                  "type": "string"
+                "casesAverted": {
+                  "type": "number"
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "population",
-                "seasonalityOfTransmission",
-                "currentPrevalence",
-                "bitingIndoors",
-                "bitingPeople",
-                "levelOfResistance",
-                "itnUsage",
-                "sprayInput"
-              ]
-            },
-            "interventionSettings": {
-              "type": "object",
-              "properties": {
-                "procurePeoplePerNet": {
-                  "type": "number"
-                },
-                "procureBuffer": {
-                  "type": "number"
-                },
-                "priceDelivery": {
-                  "type": "number"
-                },
-                "priceNetPBO": {
-                  "type": "number"
-                },
-                "priceNetPyrrole":{
-                  "type": "number"
-                },
-                "priceNetStandard": {
-                  "type": "number"
-                },
-                "priceIRSPerPerson": {
-                  "type": "number"
-                },
-                "netUse": {
-                  "type": "string"
-                },
-                "irsUse": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "procurePeoplePerNet",
-                "procureBuffer",
-                "priceDelivery",
-                "priceNetPBO",
-                "priceNetPyrrole",
-                "priceNetStandard",
-                "priceIRSPerPerson",
-                "netUse",
-                "irsUse"
-              ]
+              "required": ["intervention", "cost", "casesAverted"]
             }
           }
-        }
-      ]
+        },
+        "additionalProperties": false,
+        "required": ["region", "interventions"]
+      }
     }
   },
   "additionalProperties": false,
-  "required": [
-    "budget",
-    "zones"
-  ]
+  "required": ["budget", "regions"]
 }

--- a/tests/testthat/helper-mintr.R
+++ b/tests/testthat/helper-mintr.R
@@ -11,3 +11,27 @@ mintr_test_db_init <- function() {
     mintr_db_download("data")
   }
 }
+
+create_strategise_test_data <- function() {
+  json_txt <- '{
+  "budget": 10000,
+  "regions": [
+    {"region": "Region A", "interventions": [
+      {"intervention": "lsm_only", "cost": 1000, "casesAverted": 50}
+    ]},
+    {"region": "Region B", "interventions": [
+      {"intervention": "irs_only", "cost": 1500, "casesAverted": 70},
+      {"intervention": "lsm_only", "cost": 2500, "casesAverted": 150},
+      {"intervention": "py_only", "cost": 3000, "casesAverted": 200}
+    ]},
+    {"region": "Region C", "interventions": [
+      {"intervention": "irs_only", "cost": 2000, "casesAverted": 80},
+      {"intervention": "lsm_only", "cost": 3000, "casesAverted": 160},
+      {"intervention": "py_only", "cost": 3500, "casesAverted": 220},
+      {"intervention": "py_pbo_with_lsm", "cost": 4500, "casesAverted": 320}
+    ]}
+  ]
+}'
+  jsonlite::fromJSON(json_txt, flatten = TRUE, simplifyVector = TRUE)
+}
+

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -321,10 +321,9 @@ test_that("strategise", {
   expect_equal(body$status, "success")
   expect_equal(body$data$costThreshold, c(1.0, 0.95, 0.9, 0.85, 0.8))
 
-  for (i in seq_along(result)) {
-      expect_true("costThreshold" %in% names(result[[i]]))
-      expect_true("interventions" %in% names(result[[i]]))
-      expect_equal(nrow(result[[i]]$interventions), 3) # 1 for each region
+  interventions <- body$data$interventions
+  for (i in seq_along(interventions)) {
+      expect_equal(nrow(interventions[[i]]), 3) # 1 for each region
     }
 })
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -309,67 +309,23 @@ test_that("cost docs", {
   expect_equal(res_api$body, res_endpoint$body)
 })
 
-test_that("cost", {
-  expected_costs <- get_expected_total_costs()
-  interventions <- c("none", "llin", "llin-pbo", "pyrrole-pbo", "irs", "irs-llin", "irs-llin-pbo", "irs-pyrrole-pbo")
-  for (i in seq_along(expected_costs)) {
-    expect_equal(get_cost(get_input(), get_input(), interventions[i]), expected_costs[[i]])
-  }
-})
-
 test_that("strategise", {
-  baseline_settings <- list(
-    population = 1000,
-    seasonalityOfTransmission = "seasonal",
-    currentPrevalence = "30%",
-    bitingIndoors = "high",
-    bitingPeople = "low",
-    levelOfResistance = "0%",
-    itnUsage = "0%",
-    sprayInput = "0%"
-  )
-  intervention_settings <- list(
-    netUse = "0",
-    irsUse = "0",
-    procurePeoplePerNet = 1,
-    procureBuffer = 2,
-    priceDelivery = 3,
-    priceNetStandard = 4,
-    priceNetPBO = 5,
-    priceNetPyrrole = 6,
-    priceIRSPerPerson = 6
-  )
-  json <- jsonlite::toJSON(list(
-    budget = 52500,
-    zones = list(
-      list(name = "Region A", baselineSettings = baseline_settings,
-           interventionSettings = intervention_settings),
-      list(name = "Region B", baselineSettings = baseline_settings,
-           interventionSettings = modifyList(intervention_settings,
-                                             list(irsUse = 0.8))),
-      list(name = "Region C", baselineSettings = baseline_settings,
-           interventionSettings = modifyList(intervention_settings,
-                                             list(netUse = 0.4))),
-      list(name = "Region D", baselineSettings = baseline_settings,
-           interventionSettings = modifyList(intervention_settings,
-                                             list(irsUse = 0.8, netUse = 0.4)))
-    )
-  ), auto_unbox=TRUE)
-
-  db <- mintr_test_db()
-  res <- target_strategise(db)(json)
-  expect_s3_class(res, "json")
-
-  endpoint <- endpoint_strategise(db)
-  res_endpoint <- endpoint$run(json)
-  expect_equal(res_endpoint$status_code, 200)
-  expect_equal(res_endpoint$content_type, "application/json")
-  expect_equal(res_endpoint$data, res)
-
+  test_data <- jsonlite::toJSON(create_strategise_test_data(), auto_unbox = TRUE)
+  db <- mintr_test_db() 
   api <- api_build(db)
-  res_api <- api$request("POST", "/strategise", body = json)
+  
+  res_api <- api$request("POST", "/strategise", body = test_data)
+  
   expect_equal(res_api$status, 200)
-  expect_equal(res_api$body, res_endpoint$body)
+  body <- jsonlite::fromJSON(res_api$body)
+  expect_equal(body$status, "success")
+  expect_equal(body$data$costThreshold, c(1.0, 0.95, 0.9, 0.85, 0.8))
+
+  for (i in seq_along(result)) {
+      expect_true("costThreshold" %in% names(result[[i]]))
+      expect_true("interventions" %in% names(result[[i]]))
+      expect_equal(nrow(result[[i]]$interventions), 3) # 1 for each region
+    }
 })
 
 test_that("runs emulator and returns cases and prevalence", {

--- a/tests/testthat/test-optimise.R
+++ b/tests/testthat/test-optimise.R
@@ -1,6 +1,6 @@
 get_data <- function() {
   tibble::tribble(
-    ~zone, ~intervention,                  ~cost,            ~cases_averted,
+    ~region, ~intervention,                  ~cost,            ~casesAverted,
     "A",   "No intervention",              0,                0,
     "A",   "IRS only",                     2107590,          357880.968553733,
     "A",   "Pyrethroid-only ITN only",         351510.8855,      13119.7945853333,
@@ -29,7 +29,7 @@ test_that("optimise gives the expected results", {
   expect_equal(res_reduced_cost, as.data.frame(slice(data, 4, 12)))
 
   expect_lte(sum(res_reduced_cost$cost), sum(res_full_cost$cost))
-  expect_lte(sum(res_reduced_cost$cases_averted), sum(res_full_cost$cases_averted))
+  expect_lte(sum(res_reduced_cost$casesAverted), sum(res_full_cost$casesAverted))
 })
 
 test_that("optimise gives the expected results with minimal cost", {

--- a/tests/testthat/test-strategise.R
+++ b/tests/testthat/test-strategise.R
@@ -1,0 +1,103 @@
+
+library(jsonlite)
+library(dplyr)
+library(purrr)
+
+test_that("add_no_intervention adds no_intervention row correctly", {
+  # Test with sample interventions data
+  interventions_df <- data.frame(
+    intervention = c("lsm_only", "irs_only"),
+    cost = c(1000, 1500),
+    casesAverted = c(50, 70)
+  )
+  
+  result <- add_no_intervention(interventions_df)
+  
+  expect_equal(nrow(result), 3)
+  expect_true("no_intervention" %in% result$intervention)
+  
+  no_intervention_row <- result |> filter(intervention == "no_intervention")
+  expect_equal(no_intervention_row$cost, 0)
+  expect_equal(no_intervention_row$casesAverted, 0)
+})
+
+test_that("add_no_intervention works with empty interventions", {
+  empty_df <- data.frame(
+  intervention = character(0),
+  cost = numeric(0),
+  casesAverted = numeric(0)
+  )
+  
+  result <- add_no_intervention(empty_df)
+  
+  expect_equal(nrow(result), 1)
+  expect_equal(result$intervention, "no_intervention")
+  expect_equal(result$cost, 0)
+  expect_equal(result$casesAverted, 0)
+})
+
+test_that("combine_region_data processes regions correctly", {  
+  # Test with subset of regions
+  regions_subset <- create_strategise_test_data()$regions  
+  result <- combine_region_data(regions_subset)
+
+  expect_equal(sum(result$region == "Region A"), 2) # 1 original + 1 no_intervention
+  expect_equal(sum(result$region == "Region B"), 4) # 3 original + 1 no_intervention
+  expect_equal(sum(result$region == "Region C"), 5) # 4 original + 1 no_intervention
+})
+
+test_that("combine_region_data handles single region", {
+  single_region <- create_strategise_test_data()$regions[1, , drop = FALSE]
+  
+  result <- combine_region_data(single_region)
+  
+  expect_true(nrow(result) > 0)
+  expect_true("no_intervention" %in% result$intervention)
+  expect_equal(sum(result$intervention == "no_intervention"), 1)
+})
+
+test_that("strategise returns correct structure", {
+    result <- strategise(create_strategise_test_data())
+    
+    # Check that result is a list with 5 elements (one for each threshold)
+    expect_equal(length(result), 5)
+    
+    # Check structure of each threshold result
+    for (i in seq_along(result)) {
+      expect_true("costThreshold" %in% names(result[[i]]))
+      expect_true("interventions" %in% names(result[[i]]))
+      expect_equal(nrow(result[[i]]$interventions), 3) # 1 for each region
+    }
+    
+    # Check that cost thresholds are correct
+    expected_thresholds <- c(1, 0.95, 0.9, 0.85, 0.8)
+    actual_thresholds <- sapply(result, function(x) x$costThreshold)
+    expect_equal(actual_thresholds, expected_thresholds)
+})
+
+test_that("strategise applies budget thresholds correctly", {
+  # Mock do_optimise to capture budget parameter
+  budgets_used <- c()
+  
+  with_mocked_bindings(
+  do_optimise = function(data, budget) {
+    budgets_used <<- c(budgets_used, budget)
+    data.frame(
+    region = "Region A",
+    intervention = "lsm_only",
+    cost = 1000,
+    casesAverted = 50
+    )
+  },
+  {
+    test_data <- create_strategise_test_data()
+    result <- strategise(test_data)
+
+    expected_budgets <- test_data$budget * c(1, 0.95, 0.9, 0.85, 0.8)
+    expect_equal(budgets_used, expected_budgets)
+  }
+  )
+})
+
+
+

--- a/tests/testthat/test-strategise.R
+++ b/tests/testthat/test-strategise.R
@@ -36,20 +36,20 @@ test_that("add_no_intervention works with empty interventions", {
   expect_equal(result$casesAverted, 0)
 })
 
-test_that("combine_region_data processes regions correctly", {  
+test_that("unnest_region_data processes regions correctly", {  
   # Test with subset of regions
   regions_subset <- create_strategise_test_data()$regions  
-  result <- combine_region_data(regions_subset)
+  result <- unnest_region_data(regions_subset)
 
   expect_equal(sum(result$region == "Region A"), 2) # 1 original + 1 no_intervention
   expect_equal(sum(result$region == "Region B"), 4) # 3 original + 1 no_intervention
   expect_equal(sum(result$region == "Region C"), 5) # 4 original + 1 no_intervention
 })
 
-test_that("combine_region_data handles single region", {
+test_that("unnest_region_data handles single region", {
   single_region <- create_strategise_test_data()$regions[1, , drop = FALSE]
   
-  result <- combine_region_data(single_region)
+  result <- unnest_region_data(single_region)
   
   expect_true(nrow(result) > 0)
   expect_true("no_intervention" %in% result$intervention)


### PR DESCRIPTION
The following PR makes updates for `/stragise` endpoint. The main change is that we will now pass in the costs, cases averted data for each intervention, as we know have the data in the svelte app. 

Most logic is cleanup because less work is now required. As now we dont need to do cost calcluation etc and data manipluation.